### PR TITLE
add handler to ensure Consul Registrator is running during Scale Out events

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,6 +55,14 @@ pull_request_rules:
       add:
       - feral-testkit
       remove: []
+- name: Label registrator-health-check PRs
+  conditions:
+  - files~=^registrator-health-check/
+  actions:
+    label:
+      add:
+      - registrator-health-check
+      remove: []
 - name: Label smithy4s PRs
   conditions:
   - files~=^smithy4s/

--- a/aws-testkit/src/main/scala/com/dwolla/NextPageTokens.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/NextPageTokens.scala
@@ -1,10 +1,14 @@
 package com.dwolla
 
-object NextPageTokens {
-  def tokenForIdx(idx: Long, lastPage: Int): Option[String] =
-    if (idx == 0 || idx == lastPage) None
-    else Option(s"page-$idx")
+import monix.newtypes.NewtypeWrapped
 
-  def tokenForIdx(idx: Int, lastPage: Int): Option[String] =
+type NextPageToken = NextPageToken.Type
+object NextPageToken extends NewtypeWrapped[Option[String]]
+
+object NextPageTokens {
+  def tokenForIdx(idx: Long, lastPage: Int): NextPageToken =
+    NextPageToken(Option.unless(idx == 0 || idx == lastPage)(s"page-$idx"))
+
+  def tokenForIdx(idx: Int, lastPage: Int): NextPageToken =
     tokenForIdx(idx.toLong, lastPage)
 }

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ArbitraryInstances.scala
@@ -8,9 +8,16 @@ trait ArbitraryInstances
   extends autoscaling.ArbitraryInstances
     with ecs.ArbitraryInstances
     with ec2.ArbitraryInstances
-    with sns.ArbitraryInstances {
+    with sns.ArbitraryInstances
+    with cloudformation.ArbitraryInstances {
 
   implicit val arbAccountId: Arbitrary[AccountId] =
     Arbitrary(Gen.listOfN(12, Gen.numChar).map(_.mkString).map(AccountId(_)))
 
+  val genTag: Gen[Tag] =
+    for {
+      key <- Gen.asciiPrintableStr.map(TagName(_))
+      value <- Gen.asciiPrintableStr.map(TagValue(_))
+    } yield Tag(key, value)
+  implicit val arbTag: Arbitrary[Tag] = Arbitrary(genTag)
 }

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ArbitraryPagination.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ArbitraryPagination.scala
@@ -1,0 +1,33 @@
+package com.dwolla
+package aws
+
+import cats.*
+import cats.syntax.all.*
+import monix.newtypes.HasExtractor
+
+object ArbitraryPagination {
+  def paginate[F[_], A](pages: List[F[A]])
+                       (using Functor[F]): Map[NextPageToken, (F[A], NextPageToken)] =
+    paginateWith(pages)(identity)
+
+  def paginateWith[F[_], A, B, C](pages: A)
+                                 (transform: B => C)
+                                 (using Functor[F], HasExtractor.Aux[A, List[F[B]]]): Map[NextPageToken, (F[C], NextPageToken)] =
+    paginateWith(implicitly[HasExtractor.Aux[A, List[F[B]]]].extract(pages))(transform)
+
+  def paginateWith[F[_], A, B](pages: List[F[A]])
+                              (transform: A => B)
+                              (using Functor[F]): Map[NextPageToken, (F[B], NextPageToken)] =
+    pages
+      .zipWithIndex
+      .map {
+        case (page, index) =>
+          val key = NextPageTokens.tokenForIdx(index, pages.size)
+          val nextToken = NextPageTokens.tokenForIdx(index + 1, pages.size)
+          val transformed = page.map(transform)
+
+          key -> (transformed -> nextToken)
+      }
+      .toMap
+
+}

--- a/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/ArbitraryInstances.scala
@@ -1,17 +1,23 @@
 package com.dwolla.aws.autoscaling
 
+import cats.syntax.all.*
 import java.time.*
-
 import com.dwolla.aws.AccountId
 import com.dwolla.aws.ArbitraryInstances.*
 import com.dwolla.aws.ec2.Ec2InstanceId
 import com.fortysevendeg.scalacheck.datetime.jdk8.ArbitraryJdk8.*
-import org.scalacheck.Arbitrary.{arbitrary, arbUuid}
+import org.scalacheck.Arbitrary.{arbUuid, arbitrary}
 import org.scalacheck.*
+import LifecycleState.*
+import software.amazon.awssdk.services.autoscaling.model.{DescribeAutoScalingInstancesResponse, AutoScalingInstanceDetails}
 
 object ArbitraryInstances extends ArbitraryInstances
 
 trait ArbitraryInstances {
+  // TODO genAutoScalingGroupName could be more realistic
+  val genAutoScalingGroupName: Gen[AutoScalingGroupName] = Gen.asciiStr.map(AutoScalingGroupName(_))
+  implicit val arbAutoScalingGroupName: Arbitrary[AutoScalingGroupName] = Arbitrary(genAutoScalingGroupName)
+
   val genLifecycleHookNotification: Gen[LifecycleHookNotification] =
     for {
       service <- Gen.const("AWS Auto Scaling")
@@ -19,10 +25,55 @@ trait ArbitraryInstances {
       requestId <- arbUuid.arbitrary.map(_.toString)
       lifecycleActionToken <- arbUuid.arbitrary.map(_.toString)
       accountId <- arbitrary[AccountId]
-      groupName <- Gen.asciiStr
-      hookName <- Gen.asciiStr
+      groupName <- arbitrary[AutoScalingGroupName]
+      hookName <- Gen.asciiStr.map(LifecycleHookName(_)) // TODO move to its own Arbitrary
       ec2InstanceId <- arbitrary[Ec2InstanceId]
-      lifecycleTransition <- Gen.const("autoscaling:EC2_INSTANCE_TERMINATING")
+      lifecycleTransition <- Gen.const("autoscaling:EC2_INSTANCE_TERMINATING").map(LifecycleTransition(_)) // TODO move to its own Arbitrary
     } yield LifecycleHookNotification(service, time, requestId, lifecycleActionToken, accountId, groupName, hookName, ec2InstanceId, lifecycleTransition, None)
   implicit val arbLifecycleHookNotification: Arbitrary[LifecycleHookNotification] = Arbitrary(genLifecycleHookNotification)
+
+  val genLifecycleState: Gen[LifecycleState] =
+    Gen.frequency(
+      10 -> PendingWait,
+      1 -> PendingProceed,
+      10 -> InService,
+      10 -> TerminatingWait,
+      1 -> TerminatingProceed,
+    )
+  implicit val arbLifecycleState: Arbitrary[LifecycleState] = Arbitrary(genLifecycleState)
+
+  def genAutoScalingInstanceDetails(maybeId: Option[Ec2InstanceId] = None,
+                                    maybeAutoScalingGroupName: Option[AutoScalingGroupName] = None,
+                                    maybeLifecycleState: Option[LifecycleState] = None,
+                                   ): Gen[AutoScalingInstanceDetails] =
+    for {
+      id <- maybeId.orGen
+      asgName <- maybeAutoScalingGroupName.orGen
+      lifecycleState <- maybeLifecycleState.orGen
+    } yield
+      AutoScalingInstanceDetails
+        .builder()
+        .instanceId(id.value)
+        .autoScalingGroupName(asgName.value)
+        .lifecycleState(lifecycleState.awsName)
+        .build()
+
+  val genLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse: Gen[(LifecycleHookNotification, DescribeAutoScalingInstancesResponse)] =
+    for {
+      notification <- genLifecycleHookNotification
+      groupName <- arbitrary[AutoScalingGroupName]
+      autoScalingDetailsFromHook <- genAutoScalingInstanceDetails(notification.EC2InstanceId.some, groupName.some)
+      otherAutoScalingDetails <- Gen.listOf(genAutoScalingInstanceDetails(maybeAutoScalingGroupName = groupName.some))
+    } yield {
+      notification -> DescribeAutoScalingInstancesResponse.builder()
+        .autoScalingInstances(otherAutoScalingDetails.appended(autoScalingDetailsFromHook) *)
+        .build()
+    }
+  implicit val arbLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse: Arbitrary[(LifecycleHookNotification, DescribeAutoScalingInstancesResponse)] =
+    Arbitrary(genLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse)
+}
+
+extension [A](maybeA: Option[A]) {
+  def orGen(using Arbitrary[A]): Gen[A] =
+    maybeA.fold(arbitrary[A])(Gen.const)
 }

--- a/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/TestAutoScalingAlg.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/TestAutoScalingAlg.scala
@@ -4,6 +4,6 @@ import cats.effect.*
 import com.dwolla.aws.sns.SnsTopicArn
 
 abstract class TestAutoScalingAlg extends AutoScalingAlg[IO] {
-  override def pauseAndRecurse(topic: SnsTopicArn, lifecycleHookNotification: LifecycleHookNotification): IO[Unit] = ???
-  override def continueAutoScaling(l: LifecycleHookNotification): IO[Unit] = ???
+  override def pauseAndRecurse(topic: SnsTopicArn, lifecycleHookNotification: LifecycleHookNotification): IO[Unit] = IO.raiseError(new NotImplementedError)
+  override def continueAutoScaling(l: LifecycleHookNotification): IO[Unit] = IO.raiseError(new NotImplementedError)
 }

--- a/aws-testkit/src/main/scala/com/dwolla/aws/cloudformation/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/cloudformation/ArbitraryInstances.scala
@@ -1,0 +1,22 @@
+package com.dwolla.aws.cloudformation
+
+import org.scalacheck.{Arbitrary, Gen}
+
+object ArbitraryInstances extends ArbitraryInstances
+
+trait ArbitraryInstances {
+  val genStackArn: Gen[StackArn] =
+    for {
+      region <- Gen.oneOf("us-west-2", "us-east-1")
+      accountId <- Gen.listOfN(12, Gen.numChar).map(_.mkString)
+      name <- Gen.identifier
+      id <- Gen.uuid
+    } yield StackArn(s"arn:aws:cloudformation:$region:$accountId:stack/$name/$id")
+  implicit val arbStackArn: Arbitrary[StackArn] = Arbitrary(genStackArn)
+
+  val genLogicalResourceId: Gen[LogicalResourceId] = Gen.identifier.map(LogicalResourceId(_))
+  implicit val arbLogicalResourceId: Arbitrary[LogicalResourceId] = Arbitrary(genLogicalResourceId)
+
+  val genPhysicalResourceId: Gen[PhysicalResourceId] = Gen.asciiPrintableStr.map(PhysicalResourceId(_))
+  implicit val arbPhysicalResourceId: Arbitrary[PhysicalResourceId] = Arbitrary(genPhysicalResourceId)
+}

--- a/aws-testkit/src/main/scala/com/dwolla/aws/cloudformation/TestCloudFormationAlg.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/cloudformation/TestCloudFormationAlg.scala
@@ -1,0 +1,7 @@
+package com.dwolla.aws.cloudformation
+
+import cats.effect.*
+
+abstract class TestCloudFormationAlg extends CloudFormationAlg[IO] {
+  override def physicalResourceIdFor(stack: StackArn, logicalResourceId: LogicalResourceId): IO[Option[PhysicalResourceId]] = IO.raiseError(new NotImplementedError)
+}

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ec2/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ec2/ArbitraryInstances.scala
@@ -1,9 +1,30 @@
 package com.dwolla.aws.ec2
 
 import org.scalacheck.*
+import org.scalacheck.Arbitrary.arbitrary
+import software.amazon.awssdk.services.ec2.model.{Instance, Tag as AwsTag}
 
 object ArbitraryInstances extends ArbitraryInstances
 
 trait ArbitraryInstances {
   implicit val arbEc2InstanceId: Arbitrary[Ec2InstanceId] = Arbitrary(Gen.listOfN(17, Gen.hexChar).map(_.mkString("i-", "", "")).map(Ec2InstanceId(_)))
+
+  val genAwsTag: Gen[AwsTag] =
+    for {
+      key <- Gen.identifier
+      value <- arbitrary[String]
+    } yield AwsTag.builder().key(key).value(value).build()
+
+  val genInstance: Gen[Instance] =
+    for {
+      id <- arbitrary[Ec2InstanceId]
+      tags <- Gen.nonEmptyListOf(genAwsTag)
+    } yield {
+      Instance
+        .builder()
+        .instanceId(id.value)
+        .tags(tags *)
+        .build()
+    }
+  implicit val arbInstance: Arbitrary[Instance] = Arbitrary(genInstance)
 }

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ec2/TestEc2Alg.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ec2/TestEc2Alg.scala
@@ -1,0 +1,8 @@
+package com.dwolla.aws.ec2
+
+import cats.effect.*
+import com.dwolla.aws.Tag
+
+abstract class TestEc2Alg extends Ec2Alg[IO] {
+  override def getTagsForInstance(id: Ec2InstanceId): IO[List[Tag]] = IO.raiseError(new NotImplementedError)
+}

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ecs/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ecs/ArbitraryInstances.scala
@@ -1,11 +1,12 @@
 package com.dwolla.aws.ecs
 
-import cats.implicits.*
+import cats.syntax.all.*
 import com.dwolla.aws.AccountId
 import com.dwolla.aws.ArbitraryInstances.*
 import com.dwolla.aws.ec2.Ec2InstanceId
 import com.dwolla.RandomChunks
 import fs2.{Chunk, Stream}
+import monix.newtypes.NewtypeWrapped
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -15,8 +16,16 @@ import scala.jdk.CollectionConverters.*
 object ArbitraryInstances extends ArbitraryInstances
 
 trait ArbitraryInstances {
-  type ArbitraryCluster = List[Chunk[ClusterWithInstances]]
-  type ClusterWithInstances = (Cluster, List[Chunk[ContainerInstance]])
+  type ArbitraryCluster = ArbitraryCluster.Type
+  object ArbitraryCluster extends NewtypeWrapped[List[Chunk[ClusterWithInstances]]]
+
+  type ClusterWithInstances = ClusterWithInstances.Type
+  object ClusterWithInstances extends NewtypeWrapped[(Cluster, List[Chunk[ContainerInstance]])] {
+    extension (cwi: ClusterWithInstances) {
+      def cluster: Cluster = cwi.value._1
+      def pages: List[Chunk[ContainerInstance]] = cwi.value._2
+    }
+  }
 
   lazy val genRegion: Gen[Region] = Gen.oneOf(software.amazon.awssdk.regions.Region.regions().asScala).map(x => Region(x.id()))
   implicit lazy val arbRegion: Arbitrary[Region] = Arbitrary(genRegion)
@@ -38,23 +47,23 @@ trait ArbitraryInstances {
       seed <- arbitrary[Long]
       cluster <- arbitrary[Cluster]
       instances <- Gen.containerOf[List, ContainerInstance](arbContainerInstance.arbitrary).map(_.take(10)).map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
-    } yield cluster -> instances
+    } yield ClusterWithInstances(cluster -> instances)
   implicit lazy val arbClusterWithInstances: Arbitrary[ClusterWithInstances] = Arbitrary(genClusterWithInstances)
 
-  lazy val genClustersWithInstances: Gen[ArbitraryCluster] = {
+  lazy val genClustersWithInstances: Gen[ArbitraryCluster] =
     Gen.long.flatMap { seed =>
       Gen.nonEmptyContainerOf[List, ClusterWithInstances](arbitrary[ClusterWithInstances])
-        .suchThat { (f: List[(Cluster, List[Chunk[ContainerInstance]])]) =>
-          lazy val containerInstanceCount = f.unorderedFoldMap(_._2.flatMap(_.toList).size)
-          lazy val containerInstanceIdsAreUnique = f.flatMap(_._2.flatMap(_.toList).map(_.containerInstanceId)).toSet.size == containerInstanceCount
-          lazy val ec2InstanceIdsAreUnique = f.flatMap(_._2.flatMap(_.toList).map(_.ec2InstanceId)).toSet.size == containerInstanceCount
+        .suchThat { (f: List[ClusterWithInstances]) =>
+          lazy val containerInstanceCount = f.unorderedFoldMap(_.value._2.flatMap(_.toList).size)
+          lazy val containerInstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.containerInstanceId)).toSet.size == containerInstanceCount
+          lazy val ec2InstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.ec2InstanceId)).toSet.size == containerInstanceCount
 
           containerInstanceIdsAreUnique && ec2InstanceIdsAreUnique && containerInstanceCount > 0
         }
         .map(_.take(100))
         .map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
+        .map(ArbitraryCluster(_))
     }
-  }
   implicit lazy val arbClustersWithInstances: Arbitrary[ArbitraryCluster] = Arbitrary(genClustersWithInstances)
   implicit val shrinkArbitraryCluster: Shrink[ArbitraryCluster] = Shrink.shrinkAny
 
@@ -80,4 +89,38 @@ trait ArbitraryInstances {
   lazy val genTaskCount: Gen[TaskCount] =
     Gen.chooseNum(0, 20).map(TaskCount(_))
   implicit lazy val arbTaskCount: Arbitrary[TaskCount] = Arbitrary(genTaskCount)
+
+  val genTaskStatus: Gen[TaskStatus] =
+    Gen.frequency(1 -> TaskStatus.Pending, 10 -> TaskStatus.Running, 1 -> TaskStatus.Stopped)
+  implicit val arbTaskStatus: Arbitrary[TaskStatus] = Arbitrary(genTaskStatus)
+
+  val genTaskArn: Gen[TaskArn] =
+    for {
+      region <- genRegion
+      accountId <- arbitrary[AccountId]
+      taskId <- Gen.identifier
+    } yield TaskArn(s"arn:aws:ecs:$region:$accountId:task/$taskId")
+  implicit val arbTaskArn: Arbitrary[TaskArn] = Arbitrary(genTaskArn)
+
+  val genTask: Gen[(TaskArn, TaskStatus, TaskDefinitionArn)] =
+    for {
+      arn <- genTaskArn
+      status <- arbitrary[TaskStatus]
+      defnArn <- arbitrary[TaskDefinitionArn]
+    } yield (arn, status, defnArn)
+  val genListTaskPages: Gen[ListTaskPages] =
+    Gen.nonEmptyListOf(Gen.nonEmptyListOf(genTask)).map(ListTaskPages(_))
+  implicit val arbListTaskPages: Arbitrary[ListTaskPages] = Arbitrary(genListTaskPages)
+
+  val genTaskDefinitionArn: Gen[TaskDefinitionArn] =
+    for {
+      region <- genRegion
+      accountId <- arbitrary[AccountId]
+      name <- Gen.identifier
+      revision <- Gen.posNum[Int]
+    } yield TaskDefinitionArn(s"arn:aws:ecs:$region:$accountId:task-definition/$name:$revision")
+  implicit val arbTaskDefinitionArn: Arbitrary[TaskDefinitionArn] = Arbitrary(genTaskDefinitionArn)
 }
+
+type ListTaskPages = ListTaskPages.Type
+object ListTaskPages extends NewtypeWrapped[List[List[(TaskArn, TaskStatus, TaskDefinitionArn)]]]

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ecs/TestEcsAlg.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ecs/TestEcsAlg.scala
@@ -7,6 +7,7 @@ import com.dwolla.aws.ecs.*
 abstract class TestEcsAlg extends EcsAlg[IO, List] {
   override def listClusterArns: List[ClusterArn] = ???
   override def listContainerInstances(cluster: ClusterArn): List[ContainerInstance] = ???
-  override def findEc2Instance(ec2InstanceId: Ec2InstanceId): IO[Option[(ClusterArn, ContainerInstance)]] = ???
-  override def drainInstanceImpl(cluster: ClusterArn, ci: ContainerInstance): IO[Unit] = ???
+  override def findEc2Instance(ec2InstanceId: Ec2InstanceId): IO[Option[(ClusterArn, ContainerInstance)]] = IO.raiseError(new NotImplementedError)
+  override def isTaskDefinitionRunningOnInstance(cluster: ClusterArn, ci: ContainerInstance, taskDefinition: TaskDefinitionArn): IO[Boolean] = IO.raiseError(new NotImplementedError)
+  override def drainInstanceImpl(cluster: ClusterArn, ci: ContainerInstance): IO[Unit] = IO.raiseError(new NotImplementedError)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -37,11 +37,15 @@ lazy val `autoscaling-ecs-core`: Project = project
         "com.dwolla" %% "fs2-utils" % "3.0.0-RC2",
         "org.typelevel" %% "feral-lambda" % "0.2.3",
         "org.typelevel" %% "log4cats-core" % "2.6.0",
-        "software.amazon.awssdk" % "autoscaling" % "2.20.69",
-        "software.amazon.awssdk" % "sns" % "2.20.69",
         "io.circe" %% "circe-parser" % "0.14.5",
         "io.monix" %% "newtypes-core" % "0.2.3",
         "io.monix" %% "newtypes-circe-v0-14" % "0.2.3",
+
+        // TODO when smithy4s is updated, hopefully these Java SDK artifacts can be replaced with smithy4s equivalents
+        "software.amazon.awssdk" % "autoscaling" % "2.20.69",
+        "software.amazon.awssdk" % "sns" % "2.20.69",
+        "software.amazon.awssdk" % "ec2" % "2.20.69",
+        "software.amazon.awssdk" % "cloudformation" % "2.20.69",
       )
     }
   )
@@ -59,6 +63,7 @@ lazy val `core-tests` = project
         "org.scalameta" %% "munit-scalacheck" % "1.0.0-M8" % Test,
         "org.typelevel" %% "scalacheck-effect-munit" % "2.0.0-M2" % Test,
         "org.typelevel" %% "log4cats-noop" % "2.6.0" % Test,
+        "org.typelevel" %% "mouse" % "1.2.1" % Test,
         "io.circe" %% "circe-literal" % "0.14.5" % Test,
         "io.circe" %% "circe-testing" % "0.14.5" % Test,
         "com.47deg" %% "scalacheck-toolbox-datetime" % "0.7.0" % Test exclude("joda-time", "joda-time"),
@@ -93,6 +98,41 @@ lazy val `autoscaling-ecs-draining-lambda` = project
       )
     },
     topLevelDirectory := None,
+    maintainer := "devops@dwolla.com",
+  )
+  .dependsOn(
+    `autoscaling-ecs-core`,
+    `aws-testkit` % Test,
+    `feral-testkit` % Test,
+  )
+  .enablePlugins(
+    UniversalPlugin,
+    JavaAppPackaging,
+  )
+
+lazy val `registrator-health-check-lambda` = project
+  .in(file("registrator-health-check"))
+  .settings(
+    libraryDependencies ++= {
+      Seq(
+        "org.typelevel" %% "feral-lambda" % "0.2.3",
+        "org.typelevel" %% "log4cats-slf4j" % "2.6.0",
+        "org.http4s" %% "http4s-ember-client" % "0.23.21",
+        "org.typelevel" %% "mouse" % "1.2.1",
+        "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1" % Runtime,
+        "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.20.0" % Runtime,
+        "org.typelevel" %% "cats-effect-testkit" % "3.5.1" % Test,
+        "org.typelevel" %% "munit-cats-effect" % "2.0.0-M3" % Test,
+        "org.scalameta" %% "munit-scalacheck" % "1.0.0-M8" % Test,
+        "org.typelevel" %% "scalacheck-effect-munit" % "2.0.0-M2" % Test,
+        "org.typelevel" %% "log4cats-noop" % "2.6.0" % Test,
+        "io.circe" %% "circe-literal" % "0.14.5" % Test,
+        "io.circe" %% "circe-testing" % "0.14.5" % Test,
+        "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2" % Test,
+      )
+    },
+    topLevelDirectory := None,
+    maintainer := "devops@dwolla.com",
   )
   .dependsOn(
     `autoscaling-ecs-core`,
@@ -134,6 +174,7 @@ lazy val `ecs-autoscaling-lifecycle-hooks` = project
   .aggregate(
     `autoscaling-ecs-core`,
     `autoscaling-ecs-draining-lambda`,
+    `registrator-health-check-lambda`,
     `core-tests`,
     `feral-testkit`,
     `aws-testkit`,

--- a/core-tests/src/test/scala/com/dwolla/aws/cloudformation/CloudFormationAlgSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/cloudformation/CloudFormationAlgSpec.scala
@@ -1,0 +1,75 @@
+package com.dwolla.aws.cloudformation
+
+import cats.effect.*
+import cats.effect.std.Dispatcher
+import com.dwolla.aws.*
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF.forAllF
+import org.scalacheck.Arbitrary
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.noop.NoOpFactory
+import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
+import software.amazon.awssdk.services.cloudformation.model.{CloudFormationException, DescribeStackResourceRequest, DescribeStackResourceResponse, StackResourceDetail}
+
+import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters.*
+
+class CloudFormationAlgSpec
+  extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with ArbitraryInstances {
+
+  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+
+  test("CloudFormationAlg should return the physical resource ID for the given parameters, if it can") {
+    forAllF { (stack: StackArn,
+               logicalResourceId: LogicalResourceId,
+               maybePhysicalResourceId: Option[PhysicalResourceId],
+              ) =>
+      Dispatcher.sequential[IO].use { dispatcher =>
+        val cfn = new CloudFormationAsyncClient {
+          override def serviceName(): String = "FakeCloudFormationAsyncClient"
+          override def close(): Unit = ()
+
+          override def describeStackResource(req: DescribeStackResourceRequest): CompletableFuture[DescribeStackResourceResponse] =
+            dispatcher.unsafeToCompletableFuture {
+              if (req.stackName() == stack.value && req.logicalResourceId() == logicalResourceId.value) {
+                maybePhysicalResourceId
+                  .fold {
+                    IO.raiseError[DescribeStackResourceResponse] {
+                      CloudFormationException.builder()
+                        .message(s"Resource ${logicalResourceId.value} does not exist for stack ${stack.value}")
+                        .build()
+                    }
+                  } { physicalResourceId =>
+                    IO.pure {
+                      DescribeStackResourceResponse.builder()
+                        .stackResourceDetail {
+                          StackResourceDetail.builder()
+                            .stackId(stack.value)
+                            .logicalResourceId(logicalResourceId.value)
+                            .physicalResourceId(physicalResourceId.value)
+                            .build()
+                        }
+                        .build()
+                    }
+                  }
+              } else {
+                IO.raiseError[DescribeStackResourceResponse] {
+                  CloudFormationException.builder()
+                    .message(s"Stack '${stack.value}' does not exist")
+                    .build()
+                }
+              }
+            }
+        }
+
+        for {
+          output <- CloudFormationAlg[IO](cfn).physicalResourceIdFor(stack, logicalResourceId)
+        } yield {
+          assertEquals(output, maybePhysicalResourceId)
+        }
+      }
+    }
+  }
+}

--- a/core-tests/src/test/scala/com/dwolla/aws/cloudformation/TestApp.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/cloudformation/TestApp.scala
@@ -1,0 +1,23 @@
+package com.dwolla.aws.cloudformation
+
+import cats.effect.*
+import cats.syntax.all.*
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.noop.NoOpFactory
+import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
+
+object TestApp extends ResourceApp.Simple {
+  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+
+  private def stackArn = StackArn(???)
+  private val logicalResourceId = LogicalResourceId(???)
+
+  override def run: Resource[IO, Unit] =
+    Resource.fromAutoCloseable(IO(CloudFormationAsyncClient.builder().build()))
+      .map(CloudFormationAlg[IO](_))
+      .evalMap { alg =>
+        alg.physicalResourceIdFor(stackArn, logicalResourceId)
+      }
+      .evalMap(IO.println)
+      .void
+}

--- a/core-tests/src/test/scala/com/dwolla/aws/ec2/Ec2AlgSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/ec2/Ec2AlgSpec.scala
@@ -1,0 +1,55 @@
+package com.dwolla.aws.ec2
+
+import cats.effect.*
+import cats.effect.std.Dispatcher
+import com.dwolla.aws.*
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF.forAllF
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.noop.NoOpFactory
+import software.amazon.awssdk.services.ec2.Ec2AsyncClient
+import software.amazon.awssdk.services.ec2.model.{DescribeInstancesRequest, DescribeInstancesResponse, Instance, Reservation}
+
+import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters.*
+
+class Ec2AlgSpec
+  extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with ArbitraryInstances {
+
+  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+
+  test("Ec2Alg should retrieve the tags for an instance") {
+    forAllF { (instance: Instance) =>
+      Dispatcher.sequential[IO].use { dispatcher =>
+        val fakeClient = new Ec2AsyncClient {
+          override def serviceName(): String = "FakeEc2AsyncClient"
+          override def close(): Unit = ()
+
+          override def describeInstances(req: DescribeInstancesRequest): CompletableFuture[DescribeInstancesResponse] =
+            dispatcher.unsafeToCompletableFuture {
+              IO.pure {
+                if (req.instanceIds().contains(instance.instanceId())) {
+                  DescribeInstancesResponse
+                    .builder()
+                    .reservations(Reservation.builder().instances(instance).build())
+                    .build()
+                } else {
+                  DescribeInstancesResponse
+                    .builder()
+                    .build()
+                }
+              }
+            }
+        }
+
+        for {
+          output <- Ec2Alg[IO](fakeClient).getTagsForInstance(Ec2InstanceId(instance.instanceId()))
+        } yield {
+          assertEquals(output, instance.tags().asScala.toList.map { tag => Tag(TagName(tag.key), TagValue(tag.value))})
+        }
+      }
+    }
+  }
+}

--- a/core-tests/src/test/scala/com/dwolla/aws/ecs/EcsAlgSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/ecs/EcsAlgSpec.scala
@@ -1,21 +1,25 @@
 package com.dwolla.aws.ecs
 
 import cats.*
-import cats.data.OptionT
+import cats.data.*
 import cats.effect.*
-import cats.implicits.*
+import cats.syntax.all.*
 import com.amazonaws.ecs.ContainerInstanceStatus.DRAINING
-import com.amazonaws.ecs.{BoxedInteger, ContainerInstanceField, DescribeContainerInstancesResponse, ECS, ListClustersResponse, ListContainerInstancesResponse, UpdateContainerInstancesStateResponse, ContainerInstance as AwsContainerInstance}
+import com.amazonaws.ecs.{BoxedInteger, ContainerInstanceField, DescribeContainerInstancesResponse, DescribeTasksResponse, DesiredStatus, ECS, LaunchType, ListClustersResponse, ListContainerInstancesResponse, ListTasksResponse, Task, TaskField, UpdateContainerInstancesStateResponse, ContainerInstance as AwsContainerInstance}
 import com.dwolla.aws.ArbitraryInstances
-import com.dwolla.NextPageTokens.tokenForIdx
 import com.dwolla.aws.ecs.*
 import fs2.{Chunk, Stream}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF.forAllF
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import com.dwolla.*
+import com.dwolla.aws.ArbitraryPagination
 
-class EcsAlgImplSpec 
+import scala.annotation.nowarn
+
+@nowarn("""msg=pattern selector should be an instance of Matchable[,]+\s+but it has unmatchable type EcsAlgSpec\.this\.ClusterWithInstances(?:\.Type)? instead""")
+class EcsAlgSpec
   extends CatsEffectSuite
     with ScalaCheckEffectSuite
     with ArbitraryInstances {
@@ -23,38 +27,32 @@ class EcsAlgImplSpec
   private implicit def loggerFactory[F[_] : Applicative]: LoggerFactory[F] = NoOpFactory[F]
 
   def fakeECS[F[_] : ApplicativeThrow](arbCluster: ArbitraryCluster): ECS[F] = new FakeECS[F] {
-    private val listClustersResponses: Map[Option[String], ListClustersResponse] = {
-      val calculated = arbCluster.zipWithIndex.map {
-        case (chunk, idx) =>
-          val result = ListClustersResponse(
-            chunk.map { case (c, _) => c.clusterArn.value }.toList.some,
-            tokenForIdx(idx + 1, arbCluster.length)
-          )
-
-          tokenForIdx(idx, arbCluster.length) -> result
+    private val listClustersResponses: Map[NextPageToken, ListClustersResponse] =
+      ArbitraryPagination.paginateWith[Chunk, ArbitraryCluster, ClusterWithInstances, ClusterArn](arbCluster) {
+        case ClusterWithInstances((c, _)) => c.clusterArn
       }
-
-      Map(calculated *).withDefaultValue(ListClustersResponse())
-    }
-
-    private val listContainerInstancesResponses: Map[(Option[ClusterArn], Option[String]), ListContainerInstancesResponse] =
-      Map.from {
-        arbCluster.flatMap(_.toList).flatMap {
-          case (c, ciChunks) =>
-            ciChunks
-              .zipWithIndex
-              .map {
-                case (chunk, idx) =>
-                  val request = c.clusterArn.some -> tokenForIdx(idx, ciChunks.length)
-                  val result = ListContainerInstancesResponse(
-                    containerInstanceArns = chunk.map(_.containerInstanceId.value).toList.some,
-                    nextToken = tokenForIdx(idx + 1, ciChunks.length),
-                  )
-
-                  request -> result
-              }
+        .view
+        .mapValues {
+          case (c, n) =>
+            ListClustersResponse(c.toList.map(_.value).some, n.value)
         }
-      }.withDefaultValue(ListContainerInstancesResponse())
+        .toMap
+
+    private val listContainerInstancesResponses: Map[Option[ClusterArn], Map[NextPageToken, ListContainerInstancesResponse]] =
+      arbCluster
+        .value
+        .flatMap(_.toList)
+        .map { cwi =>
+          val clusterArn: Option[ClusterArn] = cwi.value._1.clusterArn.some
+          val pages = ArbitraryPagination.paginate(cwi.value._2).view.mapValues {
+            case (c, n) =>
+              ListContainerInstancesResponse(c.map(_.containerInstanceId.value).toList.some, n.value)
+          }
+            .toMap
+
+          clusterArn -> pages
+        }
+        .toMap
 
     private def ciToCi(ci: ContainerInstance): AwsContainerInstance =
       AwsContainerInstance(
@@ -66,9 +64,10 @@ class EcsAlgImplSpec
 
     private val clusterMap: Map[ClusterArn, List[ContainerInstance]] = Foldable[List].fold {
       arbCluster
+        .value
         .flatMap(_.toList)
         .flatMap {
-          case (c: Cluster, cis: List[Chunk[ContainerInstance]]) =>
+          case ClusterWithInstances((c, cis)) =>
             cis
               .flatMap(_.toList)
               .map(ci => Map(c.clusterArn -> List(ci)))
@@ -76,15 +75,18 @@ class EcsAlgImplSpec
     }
 
     override def listClusters(nextToken: Option[String], maxResults: Option[BoxedInteger]): F[ListClustersResponse] =
-      listClustersResponses(nextToken).pure[F]
+      listClustersResponses(NextPageToken(nextToken)).pure[F]
 
     override def listContainerInstances(cluster: Option[String],
                                         filter: Option[String],
                                         nextToken: Option[String],
                                         maxResults: Option[BoxedInteger],
-                                        status: Option[com.amazonaws.ecs.ContainerInstanceStatus]): F[ListContainerInstancesResponse] = {
-      listContainerInstancesResponses(cluster.map(ClusterArn(_)) -> nextToken).pure[F]
-    }
+                                        status: Option[com.amazonaws.ecs.ContainerInstanceStatus]): F[ListContainerInstancesResponse] =
+      listContainerInstancesResponses
+        .get(cluster.map(ClusterArn(_)))
+        .flatMap(_.get(NextPageToken(nextToken)))
+        .getOrElse(ListContainerInstancesResponse())
+        .pure[F]
 
     override def describeContainerInstances(containerInstances: List[String],
                                             cluster: Option[String],
@@ -104,7 +106,7 @@ class EcsAlgImplSpec
         .compile
         .toList
         .map { obtained =>
-          val expected = arbCluster.flatMap(_.toList).map(tuple => tuple._1.clusterArn)
+          val expected = arbCluster.value.flatMap(_.toList).map(_.cluster.clusterArn)
           assertEquals(obtained, expected)
         }
     }
@@ -114,10 +116,10 @@ class EcsAlgImplSpec
     forAllF { (arbCluster: ArbitraryCluster) =>
       val testClass = EcsAlg[IO](fakeECS(arbCluster))
 
-      Stream.emits(arbCluster)
+      Stream.emits(arbCluster.value)
         .unchunks
         .covary[IO]
-        .evalMap { case (expectedCluster, expectedContainerInstanceChunks) =>
+        .evalMap { case ClusterWithInstances((expectedCluster, expectedContainerInstanceChunks)) =>
           testClass
             .listContainerInstances(expectedCluster.clusterArn)
             .compile
@@ -135,8 +137,8 @@ class EcsAlgImplSpec
   test("EcsAlg should return the matching container instance when asked to search by EC2 Instance ID") {
     forAllF { (arbCluster: ArbitraryCluster) =>
       val testClass = EcsAlg[IO](fakeECS(arbCluster))
-      val (expectedCluster, expectedCI) = arbCluster.flatMap(_.toList).find(_._2.flatMap(_.toList).nonEmpty).flatMap {
-        case (c, cis) => cis.flatMap(_.toList).lastOption.map(c -> _)
+      val (expectedCluster, expectedCI) = arbCluster.value.flatMap(_.toList).find(_.pages.flatMap(_.toList).nonEmpty).flatMap {
+        case ClusterWithInstances((c, cis)) => cis.flatMap(_.toList).lastOption.map(c -> _)
       }.getOrElse(throw new RuntimeException("test setup exception; no container instances were found in the arbitrary cluster"))
 
       OptionT(testClass.findEc2Instance(expectedCI.ec2InstanceId))
@@ -181,6 +183,73 @@ class EcsAlgImplSpec
       val activeContainerInstance = ci.copy(status = ContainerInstanceStatus.Draining)
 
       EcsAlg[IO](new FakeECS[IO] {}).drainInstance(cluster, activeContainerInstance)
+    }
+  }
+
+  test("EcsAlg should be able to determine if an ECS Task is running on a given Container Instance") {
+    forAllF { (arbCluster: ClusterArn,
+               arbCi: ContainerInstance,
+               arbTaskDefinition: TaskDefinitionArn,
+               arbTaskStatus: Option[(TaskArn, TaskStatus)],
+               arbOtherTasks: ListTaskPages,
+              ) =>
+      val allTaskPages = arbTaskStatus.foldl(arbOtherTasks.value) { case (otherTasks, (taskArn, status)) =>
+        otherTasks appended List((taskArn, status, arbTaskDefinition))
+      }
+
+      val taskPages: Map[NextPageToken, (List[TaskArn], NextPageToken)] =
+        ArbitraryPagination.paginateWith(allTaskPages) {
+          case (arn, _, _) => arn
+        }
+
+      val allTasks: Map[TaskArn, (TaskStatus, TaskDefinitionArn)] =
+        allTaskPages.flatten.map { case (a, s, tda) => a -> (s, tda) }.toMap
+
+      val alg = EcsAlg(new FakeECS[IO] {
+        override def listTasks(cluster: Option[String],
+                               containerInstance: Option[String],
+                               family: Option[String],
+                               nextToken: Option[String],
+                               maxResults: Option[BoxedInteger],
+                               startedBy: Option[String],
+                               serviceName: Option[String],
+                               desiredStatus: Option[DesiredStatus],
+                               launchType: Option[LaunchType]): IO[ListTasksResponse] = IO.pure {
+          if (cluster.contains(arbCluster.value) && containerInstance.contains(arbCi.containerInstanceId.value) && family.isEmpty) {
+            ListTasksResponse.apply.tupled {
+              taskPages.get(NextPageToken(nextToken))
+                .separate
+                .map(_.flatMap(_.value))
+                .leftMap(_.map(_.map(_.value)))
+            }
+          } else {
+            ListTasksResponse(None, None)
+          }
+        }
+
+        override def describeTasks(tasks: List[String],
+                                   cluster: Option[String],
+                                   include: Option[List[TaskField]]): IO[DescribeTasksResponse] =
+          DescribeTasksResponse(tasks = Option.when(cluster.contains(arbCluster.value)) {
+            tasks
+              .map(TaskArn(_))
+              .mproduct(allTasks.get(_).toList)
+              .map { case (taskArn, (status, taskDefinitionArn)) =>
+                Task(
+                  clusterArn = cluster,
+                  lastStatus = status.toString.some,
+                  taskDefinitionArn = taskDefinitionArn.value.some,
+                  taskArn = taskArn.value.some,
+                )
+              }
+          }).pure[IO]
+      })
+
+      for {
+        output <- alg.isTaskDefinitionRunningOnInstance(arbCluster, arbCi, arbTaskDefinition)
+      } yield {
+        assertEquals(output, arbTaskStatus.map(_._2).contains(TaskStatus.Running)) // TODO figure out why this compiled without the .map(_._2) part before
+      }
     }
   }
 }

--- a/core/src/main/scala/com/dwolla/aws/autoscaling/AutoScalingAlg.scala
+++ b/core/src/main/scala/com/dwolla/aws/autoscaling/AutoScalingAlg.scala
@@ -3,13 +3,16 @@ package com.dwolla.aws.autoscaling
 import cats.effect.*
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
+import com.dwolla.aws.autoscaling.LifecycleState.*
 import com.dwolla.aws.sns.*
+import com.dwolla.aws.ec2.*
 import io.circe.syntax.*
 import org.typelevel.log4cats.{Logger, LoggerFactory}
 import software.amazon.awssdk.services.autoscaling.*
-import software.amazon.awssdk.services.autoscaling.model.CompleteLifecycleActionRequest
+import software.amazon.awssdk.services.autoscaling.model.{CompleteLifecycleActionRequest, DescribeAutoScalingInstancesRequest}
 
 import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
 
 trait AutoScalingAlg[F[_]] {
   def pauseAndRecurse(topic: SnsTopicArn, lifecycleHookNotification: LifecycleHookNotification): F[Unit]
@@ -24,20 +27,41 @@ object AutoScalingAlg {
 
 class AutoScalingAlgImpl[F[_] : Async : LoggerFactory](autoScalingClient: AutoScalingAsyncClient,
                                                        sns: SnsAlg[F]) extends AutoScalingAlg[F] {
+  private def getInstanceLifecycleState(ec2Instance: Ec2InstanceId): F[Option[LifecycleState]] =
+    LoggerFactory[F].create.flatMap { implicit logger =>
+      for {
+        _ <- Logger[F].info(s"checking lifecycle state for instance $ec2Instance")
+        req = DescribeAutoScalingInstancesRequest.builder().instanceIds(ec2Instance.value).build()
+        resp <- Async[F].fromCompletableFuture(Sync[F].delay(autoScalingClient.describeAutoScalingInstances(req)))
+      } yield
+        resp
+          .autoScalingInstances()
+          .asScala
+          .collectFirst {
+            case instance if Ec2InstanceId(instance.instanceId()) == ec2Instance =>
+              LifecycleState.fromString(instance.lifecycleState())
+          }
+          .flatten
+    }
+  
   override def pauseAndRecurse(t: SnsTopicArn, l: LifecycleHookNotification): F[Unit] = {
     val sleepDuration = 5.seconds
 
     LoggerFactory[F].create.flatMap { implicit logger =>
       Logger[F].info(s"Sleeping for $sleepDuration, then restarting Lambda") >>
-        sns.publish(t, l.asJson.noSpaces)
-          .delayBy(sleepDuration)
+        getInstanceLifecycleState(l.EC2InstanceId)
+          .map(_.contains(PendingWait))
+          .ifM(
+            sns.publish(t, l.asJson.noSpaces).delayBy(sleepDuration),
+            Logger[F].info("Instance not in PendingWait status; refusing to republish the SNS message")
+          )
     }
   }
 
   override def continueAutoScaling(l: LifecycleHookNotification): F[Unit] = {
     val req = CompleteLifecycleActionRequest.builder()
-      .lifecycleHookName(l.lifecycleHookName)
-      .autoScalingGroupName(l.autoScalingGroupName)
+      .lifecycleHookName(l.lifecycleHookName.value)
+      .autoScalingGroupName(l.autoScalingGroupName.value)
       .lifecycleActionResult("CONTINUE")
       .instanceId(l.EC2InstanceId.value)
       .build()

--- a/core/src/main/scala/com/dwolla/aws/cloudformation/CloudFormationAlg.scala
+++ b/core/src/main/scala/com/dwolla/aws/cloudformation/CloudFormationAlg.scala
@@ -1,0 +1,52 @@
+package com.dwolla.aws.cloudformation
+
+import cats.effect.*
+import cats.syntax.all.*
+import monix.newtypes.NewtypeWrapped
+import org.typelevel.log4cats.*
+import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourceRequest
+import software.amazon.awssdk.services.cloudformation.model.CloudFormationException
+
+type StackArn = StackArn.Type
+object StackArn extends NewtypeWrapped[String]
+
+type LogicalResourceId = LogicalResourceId.Type
+object LogicalResourceId extends NewtypeWrapped[String]
+
+type PhysicalResourceId = PhysicalResourceId.Type
+object PhysicalResourceId extends NewtypeWrapped[String]
+
+trait CloudFormationAlg[F[_]] {
+  def physicalResourceIdFor(stack: StackArn, logicalResourceId: LogicalResourceId): F[Option[PhysicalResourceId]]
+}
+
+object CloudFormationAlg {
+  def apply[F[_] : Async : LoggerFactory](client: CloudFormationAsyncClient): CloudFormationAlg[F] = new CloudFormationAlg[F] {
+    override def physicalResourceIdFor(stack: StackArn, logicalResourceId: LogicalResourceId): F[Option[PhysicalResourceId]] =
+      LoggerFactory[F].create.flatMap { implicit l =>
+        val req = DescribeStackResourceRequest.builder()
+          .stackName(stack.value)
+          .logicalResourceId(logicalResourceId.value)
+          .build()
+
+        Logger[F].info(s"retrieving $logicalResourceId from $stack") >>
+          Async[F]
+            .fromCompletableFuture {
+              Sync[F].delay(client.describeStackResource(req))
+            }
+            .map(_.stackResourceDetail().physicalResourceId())
+            .map(PhysicalResourceId(_).some)
+            .recoverWith {
+              case ex: CloudFormationException if ex.getMessage.startsWith(s"Resource $logicalResourceId does not exist for stack") =>
+                Logger[F]
+                  .trace(ex)(s"Could not find $logicalResourceId in $stack")
+                  .as(None)
+              case ex: CloudFormationException if ex.getMessage.startsWith(s"Stack '$stack' does not exist") =>
+                Logger[F]
+                  .trace(ex)(s"Could not find stack $stack")
+                  .as(None)
+            }
+      }
+  }
+}

--- a/core/src/main/scala/com/dwolla/aws/ec2/Ec2Alg.scala
+++ b/core/src/main/scala/com/dwolla/aws/ec2/Ec2Alg.scala
@@ -1,6 +1,45 @@
 package com.dwolla.aws.ec2
 
+import cats.effect.*
+import cats.syntax.all.*
+import com.dwolla.aws.*
 import monix.newtypes.NewtypeWrapped
+import org.typelevel.log4cats.*
+import software.amazon.awssdk.services.ec2.*
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
+
+import scala.jdk.CollectionConverters.*
 
 type Ec2InstanceId = Ec2InstanceId.Type
 object Ec2InstanceId extends NewtypeWrapped[String]
+
+trait Ec2Alg[F[_]] {
+  def getTagsForInstance(id: Ec2InstanceId): F[List[Tag]]
+}
+
+object Ec2Alg {
+  def apply[F[_]: Async : LoggerFactory](ec2Client: Ec2AsyncClient): Ec2Alg[F] = new Ec2Alg[F] {
+    override def getTagsForInstance(id: Ec2InstanceId): F[List[Tag]] = {
+      val req = DescribeInstancesRequest.builder().instanceIds(id.value).build()
+
+      LoggerFactory[F].create.flatMap { implicit L =>
+        for {
+          _ <- Logger[F].info(s"describing instance ${id.value}")
+          resp <- Async[F].fromCompletableFuture(
+            Sync[F].delay(ec2Client.describeInstances(req))
+          )
+        } yield {
+          resp
+            .reservations()
+            .asScala
+            .flatMap(_.instances().asScala)
+            .flatMap(_.tags().asScala)
+            .map { t =>
+              Tag(TagName(t.key()), TagValue(t.value()))
+            }
+            .toList
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/com/dwolla/aws/ecs/EcsAlg.scala
+++ b/core/src/main/scala/com/dwolla/aws/ecs/EcsAlg.scala
@@ -2,9 +2,10 @@ package com.dwolla.aws.ecs
 
 import cats.*
 import cats.syntax.all.*
-import com.amazonaws.ecs.ECS
+import com.amazonaws.ecs.{ECS, Task}
 import com.dwolla.aws.ec2.*
 import com.dwolla.aws.ecs.*
+import com.dwolla.aws.ecs.TaskStatus.Running
 import com.dwolla.fs2utils.Pagination
 import fs2.*
 import org.typelevel.log4cats.{Logger, LoggerFactory}
@@ -15,6 +16,10 @@ abstract class EcsAlg[F[_] : Applicative, G[_]] {
   def findEc2Instance(ec2InstanceId: Ec2InstanceId): F[Option[(ClusterArn, ContainerInstance)]]
   def drainInstance(cluster: ClusterArn, ci: ContainerInstance): F[Unit] =
     drainInstanceImpl(cluster, ci).unlessA(ci.status == ContainerInstanceStatus.Draining)
+
+  def isTaskDefinitionRunningOnInstance(cluster: ClusterArn,
+                                        ci: ContainerInstance,
+                                        taskDefinition: TaskDefinitionArn): F[Boolean]
 
   protected def drainInstanceImpl(cluster: ClusterArn, ci: ContainerInstance): F[Unit]
 }
@@ -54,12 +59,53 @@ object EcsAlg {
     override def findEc2Instance(ec2InstanceId: Ec2InstanceId): F[Option[(ClusterArn, ContainerInstance)]] =
       LoggerFactory[F].create.flatMap { implicit L =>
         listClusterArns
+          // TODO listContainerInstances could use a CQL expression to narrow the search
           .mproduct(listContainerInstances(_).filter(_.ec2InstanceId == ec2InstanceId))
           .compile
           .last
           .flatTap { ec2Instance =>
             Logger[F].info(s"EC2 Instance search results: $ec2Instance")
           }
+      }
+
+    private def listTasks(cluster: ClusterArn,
+                          ci: ContainerInstance): Stream[F, TaskArn] =
+      for {
+        given _ <- Stream.eval(LoggerFactory[F].create)
+        _ <- Stream.eval(Logger[F].info(s"listing tasks on instance ${ci.containerInstanceId.value} in cluster $cluster"))
+        taskArn <- Pagination.offsetUnfoldChunkEval { (nextToken: Option[String]) =>
+          for {
+            _ <- Logger[F].trace(s"cluster = ${cluster.value}, containerInstance = ${ci.containerInstanceId.value}, nextToken = $nextToken")
+            resp <- ecs.listTasks(
+              cluster = cluster.value.some,
+              containerInstance = ci.containerInstanceId.value.some,
+              nextToken = nextToken,
+            )
+          } yield resp.taskArns.map(Chunk.iterable(_)).getOrElse(Chunk.empty) -> resp.nextToken
+        }
+      } yield TaskArn(taskArn)
+
+    private def describeTasks(cluster: ClusterArn): Pipe[F, TaskArn, Task] =
+      _.map(_.value)
+        .chunkN(100)
+        .map(_.toList)
+        .evalMap(ecs.describeTasks(_, cluster.value.some))
+        .map(_.tasks.map(Chunk.iterable(_)).getOrElse(Chunk.empty))
+        .unchunks
+
+    override def isTaskDefinitionRunningOnInstance(cluster: ClusterArn,
+                                                   ci: ContainerInstance,
+                                                   taskDefinition: TaskDefinitionArn): F[Boolean] =
+      LoggerFactory[F].create.flatMap { implicit L =>
+        Logger[F].info(s"looking for task definition ${taskDefinition.value} on instance ${ci.containerInstanceId.value} in cluster ${cluster.value}") >>
+          listTasks(cluster, ci)
+            .through(describeTasks(cluster))
+            .filter(_.taskDefinitionArn.map(TaskDefinitionArn(_)).contains(taskDefinition))
+            .filter(_.lastStatus.flatMap(TaskStatus.fromString).contains(Running))
+            .head
+            .compile
+            .last
+            .map(_.isDefined)
       }
 
     override protected def drainInstanceImpl(cluster: ClusterArn, ci: ContainerInstance): F[Unit] =

--- a/core/src/main/scala/com/dwolla/aws/ecs/model.scala
+++ b/core/src/main/scala/com/dwolla/aws/ecs/model.scala
@@ -50,5 +50,28 @@ object ContainerInstanceStatus {
   }
 }
 
+type TaskArn = TaskArn.Type
+object TaskArn extends NewtypeWrapped[String]
+
 type TaskDefinitionArn = TaskDefinitionArn.Type
 object TaskDefinitionArn extends NewtypeWrapped[String]
+
+enum TaskStatus {
+  case Pending
+  case Running
+  case Stopped
+
+  override def toString: String = this match {
+    case Pending => "PENDING"
+    case Running => "RUNNING"
+    case Stopped => "STOPPED"
+  }
+}
+object TaskStatus {
+  def fromString(s: String): Option[TaskStatus] =
+    s match {
+      case "PENDING" => TaskStatus.Pending.some
+      case "RUNNING" => TaskStatus.Running.some
+      case "STOPPED" => TaskStatus.Stopped.some
+    }
+}

--- a/project/ServerlessDeployPlugin.scala
+++ b/project/ServerlessDeployPlugin.scala
@@ -27,6 +27,7 @@ object ServerlessDeployPlugin extends AutoPlugin {
         baseCommand ++ Seq("--stage", Stage.parser.parsed.name),
         Option((ThisBuild / baseDirectory).value),
         "DRAINING_ARTIFACT_PATH" -> (LocalProject("autoscaling-ecs-draining-lambda") / Universal / packageBin).value.toString,
+        "REGISTRATOR_ARTIFACT_PATH" -> (LocalProject("registrator-health-check-lambda") / Universal / packageBin).value.toString,
         "VERSION" -> version.value,
         "VCS_URL" -> (ThisBuild / homepage).value.get.toString,
       ).!

--- a/registrator-health-check/src/main/resources/log4j2.xml
+++ b/registrator-health-check/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/registrator-health-check/src/main/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridge.scala
+++ b/registrator-health-check/src/main/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridge.scala
@@ -1,0 +1,58 @@
+package com.dwolla.autoscaling.ecs.registrator
+
+import cats.*
+import cats.syntax.all.*
+import com.dwolla.aws.*
+import com.dwolla.aws.autoscaling.*
+import com.dwolla.aws.autoscaling.AdvanceLifecycleHook.*
+import com.dwolla.aws.cloudformation.*
+import com.dwolla.aws.ec2.Ec2Alg
+import com.dwolla.aws.ecs.EcsAlg
+import com.dwolla.aws.ecs.*
+import com.dwolla.aws.sns.SnsTopicArn
+import mouse.all.*
+
+class ScaleOutPendingEventBridge[F[_] : Monad, G[_]](ECS: EcsAlg[F, G],
+                                                     AutoScaling: AutoScalingAlg[F],
+                                                     EC2: Ec2Alg[F],
+                                                     Cfn: CloudFormationAlg[F],
+                                                    ) {
+  def apply(topic: SnsTopicArn, lifecycleHook: LifecycleHookNotification): F[Unit] =
+    ECS.findEc2Instance(lifecycleHook.EC2InstanceId)
+      .liftOptionT
+      .mproduct { case (cluster, ContainerInstance(containerInstanceId, ec2InstanceId, _, _)) =>
+        EC2.getTagsForInstance(lifecycleHook.EC2InstanceId)
+          .find(_.name == TagName("aws:cloudformation:stack-id"))
+          .liftOptionT
+          .flatMapF { case Tag(_, stackId) =>
+            Cfn.physicalResourceIdFor(StackArn(stackId.value), LogicalResourceId("registratorTaskDefinition"))
+          }
+          .map(id => TaskDefinitionArn(id.value))
+      }
+      .semiflatMap[AdvanceLifecycleHook] { case ((cluster, ci), taskDefinition) =>
+        ECS.isTaskDefinitionRunningOnInstance(cluster, ci, taskDefinition)
+          .map {
+            case true => ContinueAutoScaling
+            case false => PauseAndRecurse
+          }
+      }
+      .getOrElse(PauseAndRecurse) // EC2 instance doesn't exist in ECS cluster yet, so pause and try again later
+      .flatMap {
+        case PauseAndRecurse => AutoScaling.pauseAndRecurse(topic, lifecycleHook)
+        case ContinueAutoScaling => AutoScaling.continueAutoScaling(lifecycleHook)
+      }
+}
+
+object ScaleOutPendingEventBridge {
+  def apply[F[_] : Monad, G[_]](ecsAlg: EcsAlg[F, G],
+                                autoScalingAlg: AutoScalingAlg[F],
+                                ec2Alg: Ec2Alg[F],
+                                cloudFormationAlg: CloudFormationAlg[F],
+                               ): (SnsTopicArn, LifecycleHookNotification) => F[Unit] =
+    new ScaleOutPendingEventBridge(ecsAlg, autoScalingAlg, ec2Alg, cloudFormationAlg).apply
+}
+
+extension [F[_], G[_], A](fga: F[G[A]])(using Functor[F], Foldable[G]) {
+  def find(pred: A => Boolean): F[Option[A]] =
+    fga.map(_.find(pred))
+}

--- a/registrator-health-check/src/main/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventHandler.scala
+++ b/registrator-health-check/src/main/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventHandler.scala
@@ -1,0 +1,36 @@
+package com.dwolla.autoscaling.ecs.registrator
+
+import cats.*
+import cats.effect.*
+import com.amazonaws.ecs.ECS
+import com.dwolla.aws.autoscaling.{AutoScalingAlg, LifecycleHookHandler}
+import com.dwolla.aws.ec2.Ec2Alg
+import com.dwolla.aws.cloudformation.CloudFormationAlg
+import com.dwolla.aws.ecs.EcsAlg
+import com.dwolla.aws.sns.SnsAlg
+import feral.lambda.events.SnsEvent
+import feral.lambda.{INothing, IOLambda, LambdaEnv}
+import org.http4s.ember.client.EmberClientBuilder
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+import smithy4s.aws.http4s.*
+import smithy4s.aws.kernel.AwsRegion
+import software.amazon.awssdk.services.autoscaling.AutoScalingAsyncClient
+import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
+import software.amazon.awssdk.services.ec2.Ec2AsyncClient
+import software.amazon.awssdk.services.sns.SnsAsyncClient
+
+class ScaleOutPendingEventHandler extends IOLambda[SnsEvent, INothing] {
+  override def handler: Resource[IO, LambdaEnv[IO, SnsEvent] => IO[Option[INothing]]] =
+    for {
+      client <- EmberClientBuilder.default[IO].build
+      given LoggerFactory[IO] = Slf4jFactory.create[IO]
+      ecs <- ECS.simpleAwsClient(client, AwsRegion.US_WEST_2).map(EcsAlg(_))
+      autoscalingClient <- Resource.fromAutoCloseable(IO(AutoScalingAsyncClient.builder().build()))
+      sns <- Resource.fromAutoCloseable(IO(SnsAsyncClient.builder().build())).map(SnsAlg[IO](_))
+      ec2Client <- Resource.fromAutoCloseable(IO(Ec2AsyncClient.builder().build())).map(Ec2Alg[IO](_))
+      cloudformationClient <- Resource.fromAutoCloseable(IO(CloudFormationAsyncClient.builder().build())).map(CloudFormationAlg[IO](_))
+      autoscaling = AutoScalingAlg[IO](autoscalingClient, sns)
+      bridgeFunction = ScaleOutPendingEventBridge(ecs, autoscaling, ec2Client, cloudformationClient)
+    } yield LifecycleHookHandler[IO](bridgeFunction)
+}

--- a/registrator-health-check/src/test/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridgeSpec.scala
+++ b/registrator-health-check/src/test/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridgeSpec.scala
@@ -1,0 +1,119 @@
+package com.dwolla.autoscaling.ecs.registrator
+
+import cats.*
+import cats.effect.*
+import cats.syntax.all.*
+import com.dwolla.aws.*
+import com.dwolla.aws.autoscaling.*
+import com.dwolla.aws.autoscaling.AdvanceLifecycleHook.*
+import com.dwolla.aws.cloudformation.*
+import com.dwolla.aws.ec2.*
+import com.dwolla.aws.ecs.*
+import com.dwolla.aws.sns.SnsTopicArn
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF.forAllF
+
+class ScaleOutPendingEventBridgeSpec
+  extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with com.dwolla.aws.ArbitraryInstances {
+
+  test("ScaleOutPendingEventBridge continues autoscaling when Registrator is running on instance") {
+    forAllF { (arbTopic: SnsTopicArn,
+               arbLifecycleHook: LifecycleHookNotification,
+               arbCluster: ClusterArn,
+               arbContainerInstance: ContainerInstance,
+               arbStackArn: StackArn,
+               arbTaskDefinitionArn: TaskDefinitionArn,
+               arbTags: List[Tag],
+               arbRegistratorStatus: Boolean,
+              ) =>
+      for {
+        deferredResult <- Deferred[IO, (AdvanceLifecycleHook, Option[SnsTopicArn], LifecycleHookNotification)]
+        ecs = new TestEcsAlg {
+          override def findEc2Instance(ec2InstanceId: Ec2InstanceId): IO[Option[(ClusterArn, ContainerInstance)]] =
+            Option.when(ec2InstanceId == arbLifecycleHook.EC2InstanceId) {
+              (arbCluster, arbContainerInstance)
+            }.pure[IO]
+
+          override def isTaskDefinitionRunningOnInstance(cluster: ClusterArn,
+                                                         ci: ContainerInstance,
+                                                         taskDefinition: TaskDefinitionArn): IO[Boolean] =
+            (arbRegistratorStatus &&
+              cluster == arbCluster &&
+              ci == arbContainerInstance &&
+              taskDefinition == arbTaskDefinitionArn).pure[IO]
+        }
+        autoscaling = new FakeAutoScalingAlgThatCapturesMethodParameters(deferredResult)
+        ec2 = new FakeEc2AlgThatReturnsArbitraryTagsWithCloudFormationStackIdTag(arbLifecycleHook, arbStackArn, arbTags)
+        cloudformation = new TestCloudFormationAlg {
+          override def physicalResourceIdFor(stack: StackArn,
+                                             logicalResourceId: LogicalResourceId): IO[Option[PhysicalResourceId]] =
+            Option.when(stack == arbStackArn && logicalResourceId == LogicalResourceId("registratorTaskDefinition")) {
+              PhysicalResourceId(arbTaskDefinitionArn.value)
+            }.pure[IO]
+        }
+
+        _ <- new ScaleOutPendingEventBridge(ecs, autoscaling, ec2, cloudformation).apply(arbTopic, arbLifecycleHook)
+
+        (result, maybeTopic, capturedLifecycleHookNotification) <- deferredResult.get
+
+      } yield {
+        assertEquals(result, if (arbRegistratorStatus) ContinueAutoScaling else PauseAndRecurse)
+        assertEquals(maybeTopic, Option.unless(arbRegistratorStatus)(arbTopic))
+        assertEquals(capturedLifecycleHookNotification, arbLifecycleHook)
+      }
+    }
+  }
+
+  test("ScaleOutPendingEventBridge pauses and recurses if EC2 instance isn't found in ECS cluster") {
+    forAllF { (arbTopic: SnsTopicArn,
+               arbLifecycleHook: LifecycleHookNotification,
+               arbCluster: ClusterArn,
+               arbContainerInstance: ContainerInstance,
+               arbStackArn: StackArn,
+               arbTaskDefinitionArn: TaskDefinitionArn,
+               arbTags: List[Tag],
+              ) =>
+      for {
+        deferredResult <- Deferred[IO, (AdvanceLifecycleHook, Option[SnsTopicArn], LifecycleHookNotification)]
+        ecs = new TestEcsAlg {
+          override def findEc2Instance(ec2InstanceId: Ec2InstanceId): IO[Option[(ClusterArn, ContainerInstance)]] =
+            none[(ClusterArn, ContainerInstance)].pure[IO]
+        }
+        autoscaling = new FakeAutoScalingAlgThatCapturesMethodParameters(deferredResult)
+        ec2 = new FakeEc2AlgThatReturnsArbitraryTagsWithCloudFormationStackIdTag(arbLifecycleHook, arbStackArn, arbTags)
+        cloudformation = new TestCloudFormationAlg {}
+        _ <- new ScaleOutPendingEventBridge(ecs, autoscaling, ec2, cloudformation).apply(arbTopic, arbLifecycleHook)
+
+        (result, maybeTopic, capturedLifecycleHookNotification) <- deferredResult.get
+
+      } yield {
+        assertEquals(result, PauseAndRecurse)
+        assertEquals(maybeTopic, arbTopic.some)
+        assertEquals(capturedLifecycleHookNotification, arbLifecycleHook)
+      }
+    }
+  }
+}
+
+class FakeEc2AlgThatReturnsArbitraryTagsWithCloudFormationStackIdTag(arbLifecycleHook: LifecycleHookNotification,
+                                                                     arbStackArn: StackArn,
+                                                                     arbTags: List[Tag],
+                                                                    ) extends TestEc2Alg {
+  override def getTagsForInstance(id: Ec2InstanceId): IO[List[Tag]] =
+    IO.pure {
+      if (id == arbLifecycleHook.EC2InstanceId) arbTags ++ List(
+        Tag(TagName("aws:cloudformation:stack-id"), TagValue(arbStackArn.value)),
+      )
+      else List.empty
+    }
+}
+
+class FakeAutoScalingAlgThatCapturesMethodParameters(deferredResult: Deferred[IO, (AdvanceLifecycleHook, Option[SnsTopicArn], LifecycleHookNotification)]) extends TestAutoScalingAlg {
+  override def pauseAndRecurse(topic: SnsTopicArn, lifecycleHookNotification: LifecycleHookNotification): IO[Unit] =
+    deferredResult.complete((PauseAndRecurse, topic.some, lifecycleHookNotification)).void
+
+  override def continueAutoScaling(l: LifecycleHookNotification): IO[Unit] =
+    deferredResult.complete((ContinueAutoScaling, None, l)).void
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,16 +21,21 @@ provider:
         - Sid: CorePermissions
           Action:
             - "autoscaling:CompleteLifecycleAction"
+            - "autoscaling:DescribeAutoScalingInstances"
             - "ecs:ListClusters"
             - "ecs:ListContainerInstances"
             - "ecs:DescribeContainerInstances"
             - "ecs:UpdateContainerInstancesState"
+            - "ecs:ListTasks"
+            - "ecs:DescribeTasks"
+            - "ec2:DescribeInstances"
+            - "cloudformation:DescribeStackResource"
           Resource: "*"
           Effect: Allow
         - Sid: RepublishMessages
           Effect: Allow
           Resource:
-            - Ref: SNSTopicAutoScalingEcsDrainingNotification
+            - Ref: SNSTopicAutoScalingLifecycleHookNotifications
           Action:
             - sqs:SendMessage
             - sqs:GetQueueUrl
@@ -51,25 +56,47 @@ package:
   individually: true
 
 functions:
-  TerminationHook:
+  DrainOnTermination:
     handler: com.dwolla.autoscaling.ecs.draining.TerminationEventHandler
     package:
       artifact: ${env:DRAINING_ARTIFACT_PATH}
     events:
       - sns:
           arn:
-            Ref: SNSTopicAutoScalingEcsDrainingNotification
+            Ref: SNSTopicAutoScalingLifecycleHookNotifications
           topicName: AutoScalingEcsDrainingNotification
+          filterPolicyScope: MessageBody
+          filterPolicy:
+            LifecycleTransition:
+              - "autoscaling:EC2_INSTANCE_TERMINATING"
+            LifecycleHookName:
+              - drain-ecs-container-instance
+
+  ConfirmRegistratorHealth:
+    handler: com.dwolla.autoscaling.ecs.registrator.ScaleOutPendingEventHandler
+    package:
+      artifact: ${env:REGISTRATOR_ARTIFACT_PATH}
+    events:
+      - sns:
+          arn:
+            Ref: SNSTopicAutoScalingLifecycleHookNotifications
+          topicName: SNSTopicAutoScalingEcsScaleOutNotification
+          filterPolicyScope: MessageBody
+          filterPolicy:
+            LifecycleTransition:
+              - "autoscaling:EC2_INSTANCE_LAUNCHING"
+            LifecycleHookName:
+              - confirm-registrator-is-healthy-on-scale-out
 
 resources:
   Description:
-    Auto Scaling Lifecycle Hook that ensures an ECS Container Instance is fully drained before it is terminated by Auto Scaling
+    Auto Scaling Lifecycle Hooks for ECS Container Instances
   Resources:
-    SNSTopicAutoScalingEcsDrainingNotification:
+    SNSTopicAutoScalingLifecycleHookNotifications:
       Type: AWS::SNS::Topic
       Properties:
-        TopicName: AutoScalingEcsDrainingNotification
-    AllowPublishToSNSTopicAutoScalingEcsDrainingNotification:
+        TopicName: AutoScalingLifecycleHookNotifications
+    AllowPublishToSNSTopicAutoScalingLifecycleHookNotifications:
       Type: AWS::IAM::Role
       Properties:
         AssumeRolePolicyDocument:
@@ -81,35 +108,35 @@ resources:
               Action:
                 - sts:AssumeRole
         Policies:
-          - PolicyName: AllowPublishToSNSTopicAutoScalingEcsDrainingNotification
+          - PolicyName: AllowPublishToSNSTopicAutoScalingLifecycleHookNotifications
             PolicyDocument:
               Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Resource:
-                    - Ref: SNSTopicAutoScalingEcsDrainingNotification
+                    - Ref: SNSTopicAutoScalingLifecycleHookNotifications
                   Action:
                     - sqs:SendMessage
                     - sqs:GetQueueUrl
                     - sns:Publish
 
   Outputs:
-    SNSTopicAutoScalingEcsDrainingNotification:
+    SNSTopicAutoScalingLifecycleHookNotifications:
       Value:
-        Ref: SNSTopicAutoScalingEcsDrainingNotification
+        Ref: SNSTopicAutoScalingLifecycleHookNotifications
       Description:
         Topic used by Auto Scaling to send notifications when instance state is changing
       Export:
-        Name: sls-${self:service}-${opt:stage}-SNSTopicAutoScalingEcsDrainingNotification
-    AllowPublishToSNSTopicAutoScalingEcsDrainingNotification:
+        Name: sls-${self:service}-${opt:stage}-SNSTopicAutoScalingLifecycleHookNotifications
+    AllowPublishToSNSTopicAutoScalingLifecycleHookNotifications:
       Value:
         Fn::GetAtt:
-          - AllowPublishToSNSTopicAutoScalingEcsDrainingNotification
+          - AllowPublishToSNSTopicAutoScalingLifecycleHookNotifications
           - Arn
       Export:
-        Name: sls-${self:service}-${opt:stage}-AllowPublishToSNSTopicAutoScalingEcsDrainingNotification
+        Name: sls-${self:service}-${opt:stage}-AllowPublishToSNSTopicAutoScalingLifecycleHookNotifications
       Description:
-        IAM Role to allow Auto Scaling to publish to the SNS Topic for termination lifecycle hooks on ECS instances
+        IAM Role to allow Auto Scaling to publish to the SNS Topic for ECS instance lifecycle hooks
 
 custom:
   EnvironmentTag:


### PR DESCRIPTION
<details>
<summary>CloudFormation template generated by <code>serverless package</code></summary>

```json
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "Auto Scaling Lifecycle Hook that ensures an ECS Container Instance is fully drained before it is terminated by Auto Scaling",
  "Resources": {
    "TerminationHookLogGroup": {
      "Type": "AWS::Logs::LogGroup",
      "Properties": {
        "LogGroupName": "/aws/lambda/ecs-autoscaling-lifecycle-hooks-sandbox-TerminationHook",
        "RetentionInDays": 7
      }
    },
    "ConfirmRegistratorIsRunningOnScaleOutLogGroup": {
      "Type": "AWS::Logs::LogGroup",
      "Properties": {
        "LogGroupName": "/aws/lambda/ecs-autoscaling-lifecycle-hooks-sandbox-ConfirmRegistratorIsRunningOnScaleOut",
        "RetentionInDays": 7
      }
    },
    "IamRoleLambdaExecution": {
      "Type": "AWS::IAM::Role",
      "Properties": {
        "AssumeRolePolicyDocument": {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Principal": {
                "Service": [
                  "lambda.amazonaws.com"
                ]
              },
              "Action": [
                "sts:AssumeRole"
              ]
            }
          ]
        },
        "Policies": [
          {
            "PolicyName": {
              "Fn::Join": [
                "-",
                [
                  "ecs-autoscaling-lifecycle-hooks",
                  "sandbox",
                  "lambda"
                ]
              ]
            },
            "PolicyDocument": {
              "Version": "2012-10-17",
              "Statement": [
                {
                  "Effect": "Allow",
                  "Action": [
                    "logs:CreateLogStream",
                    "logs:CreateLogGroup",
                    "logs:TagResource"
                  ],
                  "Resource": [
                    {
                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ecs-autoscaling-lifecycle-hooks-sandbox*:*"
                    }
                  ]
                },
                {
                  "Effect": "Allow",
                  "Action": [
                    "logs:PutLogEvents"
                  ],
                  "Resource": [
                    {
                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ecs-autoscaling-lifecycle-hooks-sandbox*:*:*"
                    }
                  ]
                },
                {
                  "Sid": "CorePermissions",
                  "Action": [
                    "autoscaling:CompleteLifecycleAction",
                    "ecs:ListClusters",
                    "ecs:ListContainerInstances",
                    "ecs:DescribeContainerInstances",
                    "ecs:UpdateContainerInstancesState"
                  ],
                  "Resource": "*",
                  "Effect": "Allow"
                },
                {
                  "Sid": "RepublishMessages",
                  "Effect": "Allow",
                  "Resource": [
                    {
                      "Ref": "SNSTopicAutoScalingEcsDrainingNotification"
                    },
                    {
                      "Ref": "SNSTopicAutoScalingEcsScaleOutNotification"
                    }
                  ],
                  "Action": [
                    "sqs:SendMessage",
                    "sqs:GetQueueUrl",
                    "sns:Publish"
                  ]
                },
                {
                  "Effect": "Allow",
                  "Action": [
                    "xray:PutTraceSegments",
                    "xray:PutTelemetryRecords"
                  ],
                  "Resource": [
                    "*"
                  ]
                }
              ]
            }
          }
        ],
        "Path": "/",
        "RoleName": {
          "Fn::Join": [
            "-",
            [
              "ecs-autoscaling-lifecycle-hooks",
              "sandbox",
              {
                "Ref": "AWS::Region"
              },
              "lambdaRole"
            ]
          ]
        },
        "ManagedPolicyArns": [
          "arn:aws:iam::aws:policy/service-role/AutoScalingNotificationAccessRole"
        ]
      }
    },
    "TerminationHookLambdaFunction": {
      "Type": "AWS::Lambda::Function",
      "Properties": {
        "Code": {
          "S3Bucket": "dwolla-code-sandbox",
          "S3Key": "serverless/ecs-autoscaling-lifecycle-hooks/sandbox/1689109607476-2023-07-11T21:06:47.476Z/autoscaling-ecs-draining-lambda-b3cc6c2a17625dad57e4d37f4507955a9f2e074f.zip"
        },
        "Handler": "com.dwolla.autoscaling.ecs.draining.TerminationEventHandler",
        "Runtime": "java17",
        "FunctionName": "ecs-autoscaling-lifecycle-hooks-sandbox-TerminationHook",
        "MemorySize": 1024,
        "Timeout": 60,
        "Architectures": [
          "arm64"
        ],
        "TracingConfig": {
          "Mode": "Active"
        },
        "Role": {
          "Fn::GetAtt": [
            "IamRoleLambdaExecution",
            "Arn"
          ]
        }
      },
      "DependsOn": [
        "TerminationHookLogGroup"
      ]
    },
    "ConfirmRegistratorIsRunningOnScaleOutLambdaFunction": {
      "Type": "AWS::Lambda::Function",
      "Properties": {
        "Code": {
          "S3Bucket": "dwolla-code-sandbox",
          "S3Key": "serverless/ecs-autoscaling-lifecycle-hooks/sandbox/1689109607476-2023-07-11T21:06:47.476Z/registrator-health-check-lambda-b3cc6c2a17625dad57e4d37f4507955a9f2e074f.zip"
        },
        "Handler": "com.dwolla.autoscaling.ecs.registrator.ScaleOutPendingEventHandler",
        "Runtime": "java17",
        "FunctionName": "ecs-autoscaling-lifecycle-hooks-sandbox-ConfirmRegistratorIsRunningOnScaleOut",
        "MemorySize": 1024,
        "Timeout": 60,
        "Architectures": [
          "arm64"
        ],
        "TracingConfig": {
          "Mode": "Active"
        },
        "Role": {
          "Fn::GetAtt": [
            "IamRoleLambdaExecution",
            "Arn"
          ]
        }
      },
      "DependsOn": [
        "ConfirmRegistratorIsRunningOnScaleOutLogGroup"
      ]
    },
    "TerminationHookLambdaVersionVwOtZek3UHRiNACnVe0E6w8uDU8aAu129A7rqneTHCk": {
      "Type": "AWS::Lambda::Version",
      "DeletionPolicy": "Retain",
      "Properties": {
        "FunctionName": {
          "Ref": "TerminationHookLambdaFunction"
        },
        "CodeSha256": "N5co5H8/SD+gJm7n74roEJ5u8jVENuigu9fI0AUmc7Y="
      }
    },
    "ConfirmRegistratorIsRunningOnScaleOutLambdaVersionCFwJep0bEyXuM3ZhsdxWzojtujyFOoLQwK8HfdCV7dQ": {
      "Type": "AWS::Lambda::Version",
      "DeletionPolicy": "Retain",
      "Properties": {
        "FunctionName": {
          "Ref": "ConfirmRegistratorIsRunningOnScaleOutLambdaFunction"
        },
        "CodeSha256": "O0buyJIwkgHJ1kv8Z8Y5tKyM4Ji9wb/kI8fnQNAf9TQ="
      }
    },
    "TerminationHookSnsSubscriptionAutoScalingEcsDrainingNotification": {
      "Type": "AWS::SNS::Subscription",
      "Properties": {
        "TopicArn": {
          "Ref": "SNSTopicAutoScalingEcsDrainingNotification"
        },
        "Protocol": "lambda",
        "Endpoint": {
          "Fn::GetAtt": [
            "TerminationHookLambdaFunction",
            "Arn"
          ]
        }
      }
    },
    "TerminationHookLambdaPermissionAutoScalingEcsDrainingNotificationSNS": {
      "Type": "AWS::Lambda::Permission",
      "Properties": {
        "FunctionName": {
          "Fn::GetAtt": [
            "TerminationHookLambdaFunction",
            "Arn"
          ]
        },
        "Action": "lambda:InvokeFunction",
        "Principal": "sns.amazonaws.com",
        "SourceArn": {
          "Ref": "SNSTopicAutoScalingEcsDrainingNotification"
        }
      }
    },
    "ConfirmRegistratorIsRunningOnScaleOutSnsSubscriptionSNSTopicAutoScalingEcsScaleOutNotification": {
      "Type": "AWS::SNS::Subscription",
      "Properties": {
        "TopicArn": {
          "Ref": "SNSTopicAutoScalingEcsScaleOutNotification"
        },
        "Protocol": "lambda",
        "Endpoint": {
          "Fn::GetAtt": [
            "ConfirmRegistratorIsRunningOnScaleOutLambdaFunction",
            "Arn"
          ]
        }
      }
    },
    "ConfirmRegistratorIsRunningOnScaleOutLambdaPermissionSNSTopicAutoScalingEcsScaleOutNotificationSNS": {
      "Type": "AWS::Lambda::Permission",
      "Properties": {
        "FunctionName": {
          "Fn::GetAtt": [
            "ConfirmRegistratorIsRunningOnScaleOutLambdaFunction",
            "Arn"
          ]
        },
        "Action": "lambda:InvokeFunction",
        "Principal": "sns.amazonaws.com",
        "SourceArn": {
          "Ref": "SNSTopicAutoScalingEcsScaleOutNotification"
        }
      }
    },
    "SNSTopicAutoScalingEcsDrainingNotification": {
      "Type": "AWS::SNS::Topic",
      "Properties": {
        "TopicName": "AutoScalingEcsDrainingNotification"
      }
    },
    "AllowPublishToSNSTopicAutoScalingEcsDrainingNotification": {
      "Type": "AWS::IAM::Role",
      "Properties": {
        "AssumeRolePolicyDocument": {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Principal": {
                "Service": "autoscaling.amazonaws.com"
              },
              "Action": [
                "sts:AssumeRole"
              ]
            }
          ]
        },
        "Policies": [
          {
            "PolicyName": "AllowPublishToSNSTopicAutoScalingEcsDrainingNotification",
            "PolicyDocument": {
              "Version": "2012-10-17",
              "Statement": [
                {
                  "Effect": "Allow",
                  "Resource": [
                    {
                      "Ref": "SNSTopicAutoScalingEcsDrainingNotification"
                    }
                  ],
                  "Action": [
                    "sqs:SendMessage",
                    "sqs:GetQueueUrl",
                    "sns:Publish"
                  ]
                }
              ]
            }
          }
        ]
      }
    },
    "SNSTopicAutoScalingEcsScaleOutNotification": {
      "Type": "AWS::SNS::Topic",
      "Properties": {
        "TopicName": "SNSTopicAutoScalingEcsScaleOutNotification"
      }
    },
    "AllowPublishToSNSTopicAutoScalingEcsScaleOutNotification": {
      "Type": "AWS::IAM::Role",
      "Properties": {
        "AssumeRolePolicyDocument": {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Principal": {
                "Service": "autoscaling.amazonaws.com"
              },
              "Action": [
                "sts:AssumeRole"
              ]
            }
          ]
        },
        "Policies": [
          {
            "PolicyName": "AllowPublishToSNSTopicAutoScalingEcsScaleOutNotification",
            "PolicyDocument": {
              "Version": "2012-10-17",
              "Statement": [
                {
                  "Effect": "Allow",
                  "Resource": [
                    {
                      "Ref": "SNSTopicAutoScalingEcsScaleOutNotification"
                    }
                  ],
                  "Action": [
                    "sqs:SendMessage",
                    "sqs:GetQueueUrl",
                    "sns:Publish"
                  ]
                }
              ]
            }
          }
        ]
      }
    }
  },
  "Outputs": {
    "ServerlessDeploymentBucketName": {
      "Value": "dwolla-code-sandbox",
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-ServerlessDeploymentBucketName"
      }
    },
    "TerminationHookLambdaFunctionQualifiedArn": {
      "Description": "Current Lambda function version",
      "Value": {
        "Ref": "TerminationHookLambdaVersionVwOtZek3UHRiNACnVe0E6w8uDU8aAu129A7rqneTHCk"
      },
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-TerminationHookLambdaFunctionQualifiedArn"
      }
    },
    "ConfirmRegistratorIsRunningOnScaleOutLambdaFunctionQualifiedArn": {
      "Description": "Current Lambda function version",
      "Value": {
        "Ref": "ConfirmRegistratorIsRunningOnScaleOutLambdaVersionCFwJep0bEyXuM3ZhsdxWzojtujyFOoLQwK8HfdCV7dQ"
      },
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-ConfirmRegistratorIsRunningOnScaleOutLambdaFunctionQualifiedArn"
      }
    },
    "SNSTopicAutoScalingEcsDrainingNotification": {
      "Value": {
        "Ref": "SNSTopicAutoScalingEcsDrainingNotification"
      },
      "Description": "Topic used by Auto Scaling to send notifications when instance state is changing",
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-SNSTopicAutoScalingEcsDrainingNotification"
      }
    },
    "AllowPublishToSNSTopicAutoScalingEcsDrainingNotification": {
      "Value": {
        "Fn::GetAtt": [
          "AllowPublishToSNSTopicAutoScalingEcsDrainingNotification",
          "Arn"
        ]
      },
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-AllowPublishToSNSTopicAutoScalingEcsDrainingNotification"
      },
      "Description": "IAM Role to allow Auto Scaling to publish to the SNS Topic for termination lifecycle hooks on ECS instances"
    },
    "SNSTopicAutoScalingEcsScaleOutNotification": {
      "Value": {
        "Ref": "SNSTopicAutoScalingEcsScaleOutNotification"
      },
      "Description": "Topic used by Auto Scaling to send notifications when instance state is changing",
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-SNSTopicAutoScalingEcsScaleOutNotification"
      }
    },
    "AllowPublishToSNSTopicAutoScalingEcsScaleOutNotification": {
      "Value": {
        "Fn::GetAtt": [
          "AllowPublishToSNSTopicAutoScalingEcsScaleOutNotification",
          "Arn"
        ]
      },
      "Export": {
        "Name": "sls-ecs-autoscaling-lifecycle-hooks-sandbox-AllowPublishToSNSTopicAutoScalingEcsScaleOutNotification"
      },
      "Description": "IAM Role to allow Auto Scaling to publish to the SNS Topic for scale-out lifecycle hooks on ECS instances"
    }
  }
}
```
</details>