### PR TITLE
let each hook specify in what Lifecycle State they are allowed to recurse

### DIFF
--- a/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/TestAutoScalingAlg.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/TestAutoScalingAlg.scala
@@ -4,6 +4,6 @@ import cats.effect.*
 import com.dwolla.aws.sns.SnsTopicArn
 
 abstract class TestAutoScalingAlg extends AutoScalingAlg[IO] {
-  override def pauseAndRecurse(topic: SnsTopicArn, lifecycleHookNotification: LifecycleHookNotification): IO[Unit] = IO.raiseError(new NotImplementedError)
+  override def pauseAndRecurse(topic: SnsTopicArn, lifecycleHookNotification: LifecycleHookNotification, onlyIfInState: LifecycleState): IO[Unit] = IO.raiseError(new NotImplementedError)
   override def continueAutoScaling(l: LifecycleHookNotification): IO[Unit] = IO.raiseError(new NotImplementedError)
 }

--- a/draining/src/main/scala/com/dwolla/autoscaling/ecs/draining/TerminationEventBridge.scala
+++ b/draining/src/main/scala/com/dwolla/autoscaling/ecs/draining/TerminationEventBridge.scala
@@ -3,6 +3,7 @@ package com.dwolla.autoscaling.ecs.draining
 import cats.*
 import cats.syntax.all.*
 import com.dwolla.aws.autoscaling.*
+import com.dwolla.aws.autoscaling.LifecycleState.TerminatingWait
 import com.dwolla.aws.ecs.*
 import com.dwolla.aws.sns.SnsTopicArn
 
@@ -15,7 +16,7 @@ class TerminationEventBridge[F[_] : Monad, G[_]](ECS: EcsAlg[F, G], AutoScaling:
           ECS.drainInstance(cluster, ci).as(ci.runningTaskCount > TaskCount(0))
         case None => false.pure[F]
       }
-      _ <- if (tasksRemaining) AutoScaling.pauseAndRecurse(topic, lifecycleHook) else AutoScaling.continueAutoScaling(lifecycleHook)
+      _ <- if (tasksRemaining) AutoScaling.pauseAndRecurse(topic, lifecycleHook, TerminatingWait) else AutoScaling.continueAutoScaling(lifecycleHook)
     } yield ()
 }
 

--- a/registrator-health-check/src/main/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridge.scala
+++ b/registrator-health-check/src/main/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridge.scala
@@ -5,6 +5,7 @@ import cats.syntax.all.*
 import com.dwolla.aws.*
 import com.dwolla.aws.autoscaling.*
 import com.dwolla.aws.autoscaling.AdvanceLifecycleHook.*
+import com.dwolla.aws.autoscaling.LifecycleState.*
 import com.dwolla.aws.cloudformation.*
 import com.dwolla.aws.ec2.Ec2Alg
 import com.dwolla.aws.ecs.EcsAlg
@@ -38,7 +39,7 @@ class ScaleOutPendingEventBridge[F[_] : Monad, G[_]](ECS: EcsAlg[F, G],
       }
       .getOrElse(PauseAndRecurse) // EC2 instance doesn't exist in ECS cluster yet, so pause and try again later
       .flatMap {
-        case PauseAndRecurse => AutoScaling.pauseAndRecurse(topic, lifecycleHook)
+        case PauseAndRecurse => AutoScaling.pauseAndRecurse(topic, lifecycleHook, PendingWait)
         case ContinueAutoScaling => AutoScaling.continueAutoScaling(lifecycleHook)
       }
 }


### PR DESCRIPTION
The lambda that runs when instances are to be terminated should only recurse in the `TerminatingWait` state, not the `PendingWait` state that the scale-out hook uses.