### PR TITLE
draining instances should wait for all tasks to be STOPPED, not simply not RUNNING

### DIFF
--- a/aws-testkit/src/main/scala/com/dwolla/aws/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ArbitraryInstances.scala
@@ -2,22 +2,12 @@ package com.dwolla.aws
 
 import org.scalacheck.*
 
-object ArbitraryInstances extends ArbitraryInstances
+given Arbitrary[AccountId] =
+  Arbitrary(Gen.stringOfN(12, Gen.numChar).map(AccountId(_)))
 
-trait ArbitraryInstances
-  extends autoscaling.ArbitraryInstances
-    with ecs.ArbitraryInstances
-    with ec2.ArbitraryInstances
-    with sns.ArbitraryInstances
-    with cloudformation.ArbitraryInstances {
-
-  implicit val arbAccountId: Arbitrary[AccountId] =
-    Arbitrary(Gen.listOfN(12, Gen.numChar).map(_.mkString).map(AccountId(_)))
-
-  val genTag: Gen[Tag] =
-    for {
-      key <- Gen.asciiPrintableStr.map(TagName(_))
-      value <- Gen.asciiPrintableStr.map(TagValue(_))
-    } yield Tag(key, value)
-  implicit val arbTag: Arbitrary[Tag] = Arbitrary(genTag)
-}
+val genTag: Gen[Tag] =
+  for {
+    key <- Gen.asciiPrintableStr.map(TagName(_))
+    value <- Gen.asciiPrintableStr.map(TagValue(_))
+  } yield Tag(key, value)
+given Arbitrary[Tag] = Arbitrary(genTag)

--- a/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/autoscaling/ArbitraryInstances.scala
@@ -3,75 +3,78 @@ package com.dwolla.aws.autoscaling
 import cats.syntax.all.*
 import java.time.*
 import com.dwolla.aws.AccountId
-import com.dwolla.aws.ArbitraryInstances.*
 import com.dwolla.aws.ec2.Ec2InstanceId
 import com.fortysevendeg.scalacheck.datetime.jdk8.ArbitraryJdk8.*
 import org.scalacheck.Arbitrary.{arbUuid, arbitrary}
 import org.scalacheck.*
 import LifecycleState.*
 import software.amazon.awssdk.services.autoscaling.model.{DescribeAutoScalingInstancesResponse, AutoScalingInstanceDetails}
+import com.dwolla.aws.given 
+import com.dwolla.aws.ec2.given
 
-object ArbitraryInstances extends ArbitraryInstances
+// TODO genAutoScalingGroupName could be more realistic
+val genAutoScalingGroupName: Gen[AutoScalingGroupName] = Gen.asciiStr.map(AutoScalingGroupName(_))
+given Arbitrary[AutoScalingGroupName] = Arbitrary(genAutoScalingGroupName)
 
-trait ArbitraryInstances {
-  // TODO genAutoScalingGroupName could be more realistic
-  val genAutoScalingGroupName: Gen[AutoScalingGroupName] = Gen.asciiStr.map(AutoScalingGroupName(_))
-  implicit val arbAutoScalingGroupName: Arbitrary[AutoScalingGroupName] = Arbitrary(genAutoScalingGroupName)
+val genLifecycleHookName: Gen[LifecycleHookName] = Gen.asciiStr.map(LifecycleHookName(_))
+given Arbitrary[LifecycleHookName] = Arbitrary(genLifecycleHookName)
 
-  val genLifecycleHookNotification: Gen[LifecycleHookNotification] =
-    for {
-      service <- Gen.const("AWS Auto Scaling")
-      time <- arbitrary[ZonedDateTime].map(_.toInstant)
-      requestId <- arbUuid.arbitrary.map(_.toString)
-      lifecycleActionToken <- arbUuid.arbitrary.map(_.toString)
-      accountId <- arbitrary[AccountId]
-      groupName <- arbitrary[AutoScalingGroupName]
-      hookName <- Gen.asciiStr.map(LifecycleHookName(_)) // TODO move to its own Arbitrary
-      ec2InstanceId <- arbitrary[Ec2InstanceId]
-      lifecycleTransition <- Gen.const("autoscaling:EC2_INSTANCE_TERMINATING").map(LifecycleTransition(_)) // TODO move to its own Arbitrary
-    } yield LifecycleHookNotification(service, time, requestId, lifecycleActionToken, accountId, groupName, hookName, ec2InstanceId, lifecycleTransition, None)
-  implicit val arbLifecycleHookNotification: Arbitrary[LifecycleHookNotification] = Arbitrary(genLifecycleHookNotification)
+val genLifecycleTransition: Gen[LifecycleTransition] = Gen.const("autoscaling:EC2_INSTANCE_TERMINATING").map(LifecycleTransition(_))
+given Arbitrary[LifecycleTransition] = Arbitrary(genLifecycleTransition)
 
-  val genLifecycleState: Gen[LifecycleState] =
-    Gen.frequency(
-      10 -> PendingWait,
-      1 -> PendingProceed,
-      10 -> InService,
-      10 -> TerminatingWait,
-      1 -> TerminatingProceed,
-    )
-  implicit val arbLifecycleState: Arbitrary[LifecycleState] = Arbitrary(genLifecycleState)
+val genLifecycleHookNotification: Gen[LifecycleHookNotification] =
+  for {
+    service <- Gen.const("AWS Auto Scaling")
+    time <- arbitrary[ZonedDateTime].map(_.toInstant)
+    requestId <- arbUuid.arbitrary.map(_.toString)
+    lifecycleActionToken <- arbUuid.arbitrary.map(_.toString)
+    accountId <- arbitrary[AccountId]
+    groupName <- arbitrary[AutoScalingGroupName]
+    hookName <- arbitrary[LifecycleHookName]
+    ec2InstanceId <- arbitrary[Ec2InstanceId]
+    lifecycleTransition <- arbitrary[LifecycleTransition]
+  } yield LifecycleHookNotification(service, time, requestId, lifecycleActionToken, accountId, groupName, hookName, ec2InstanceId, lifecycleTransition, None)
+given Arbitrary[LifecycleHookNotification] = Arbitrary(genLifecycleHookNotification)
 
-  def genAutoScalingInstanceDetails(maybeId: Option[Ec2InstanceId] = None,
-                                    maybeAutoScalingGroupName: Option[AutoScalingGroupName] = None,
-                                    maybeLifecycleState: Option[LifecycleState] = None,
-                                   ): Gen[AutoScalingInstanceDetails] =
-    for {
-      id <- maybeId.orGen
-      asgName <- maybeAutoScalingGroupName.orGen
-      lifecycleState <- maybeLifecycleState.orGen
-    } yield
-      AutoScalingInstanceDetails
-        .builder()
-        .instanceId(id.value)
-        .autoScalingGroupName(asgName.value)
-        .lifecycleState(lifecycleState.awsName)
-        .build()
+val genLifecycleState: Gen[LifecycleState] =
+  Gen.frequency(
+    10 -> PendingWait,
+    1 -> PendingProceed,
+    10 -> InService,
+    10 -> TerminatingWait,
+    1 -> TerminatingProceed,
+  )
+given Arbitrary[LifecycleState] = Arbitrary(genLifecycleState)
 
-  val genLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse: Gen[(LifecycleHookNotification, DescribeAutoScalingInstancesResponse)] =
-    for {
-      notification <- genLifecycleHookNotification
-      groupName <- arbitrary[AutoScalingGroupName]
-      autoScalingDetailsFromHook <- genAutoScalingInstanceDetails(notification.EC2InstanceId.some, groupName.some)
-      otherAutoScalingDetails <- Gen.listOf(genAutoScalingInstanceDetails(maybeAutoScalingGroupName = groupName.some))
-    } yield {
-      notification -> DescribeAutoScalingInstancesResponse.builder()
-        .autoScalingInstances(otherAutoScalingDetails.appended(autoScalingDetailsFromHook) *)
-        .build()
-    }
-  implicit val arbLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse: Arbitrary[(LifecycleHookNotification, DescribeAutoScalingInstancesResponse)] =
-    Arbitrary(genLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse)
-}
+def genAutoScalingInstanceDetails(maybeId: Option[Ec2InstanceId] = None,
+                                  maybeAutoScalingGroupName: Option[AutoScalingGroupName] = None,
+                                  maybeLifecycleState: Option[LifecycleState] = None,
+                                 ): Gen[AutoScalingInstanceDetails] =
+  for {
+    id <- maybeId.orGen
+    asgName <- maybeAutoScalingGroupName.orGen
+    lifecycleState <- maybeLifecycleState.orGen
+  } yield
+    AutoScalingInstanceDetails
+      .builder()
+      .instanceId(id.value)
+      .autoScalingGroupName(asgName.value)
+      .lifecycleState(lifecycleState.awsName)
+      .build()
+
+val genLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse: Gen[(LifecycleHookNotification, DescribeAutoScalingInstancesResponse)] =
+  for {
+    notification <- genLifecycleHookNotification
+    groupName <- arbitrary[AutoScalingGroupName]
+    autoScalingDetailsFromHook <- genAutoScalingInstanceDetails(notification.EC2InstanceId.some, groupName.some)
+    otherAutoScalingDetails <- Gen.listOf(genAutoScalingInstanceDetails(maybeAutoScalingGroupName = groupName.some))
+  } yield {
+    notification -> DescribeAutoScalingInstancesResponse.builder()
+      .autoScalingInstances(otherAutoScalingDetails.appended(autoScalingDetailsFromHook) *)
+      .build()
+  }
+given Arbitrary[(LifecycleHookNotification, DescribeAutoScalingInstancesResponse)] =
+  Arbitrary(genLifecycleHookNotificationWithRelatedDescribeAutoScalingInstancesResponse)
 
 extension [A](maybeA: Option[A]) {
   def orGen(using Arbitrary[A]): Gen[A] =

--- a/aws-testkit/src/main/scala/com/dwolla/aws/cloudformation/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/cloudformation/ArbitraryInstances.scala
@@ -2,21 +2,17 @@ package com.dwolla.aws.cloudformation
 
 import org.scalacheck.{Arbitrary, Gen}
 
-object ArbitraryInstances extends ArbitraryInstances
+val genStackArn: Gen[StackArn] =
+  for {
+    region <- Gen.oneOf("us-west-2", "us-east-1")
+    accountId <- Gen.listOfN(12, Gen.numChar).map(_.mkString)
+    name <- Gen.identifier
+    id <- Gen.uuid
+  } yield StackArn(s"arn:aws:cloudformation:$region:$accountId:stack/$name/$id")
+given Arbitrary[StackArn] = Arbitrary(genStackArn)
 
-trait ArbitraryInstances {
-  val genStackArn: Gen[StackArn] =
-    for {
-      region <- Gen.oneOf("us-west-2", "us-east-1")
-      accountId <- Gen.listOfN(12, Gen.numChar).map(_.mkString)
-      name <- Gen.identifier
-      id <- Gen.uuid
-    } yield StackArn(s"arn:aws:cloudformation:$region:$accountId:stack/$name/$id")
-  implicit val arbStackArn: Arbitrary[StackArn] = Arbitrary(genStackArn)
+val genLogicalResourceId: Gen[LogicalResourceId] = Gen.identifier.map(LogicalResourceId(_))
+given Arbitrary[LogicalResourceId] = Arbitrary(genLogicalResourceId)
 
-  val genLogicalResourceId: Gen[LogicalResourceId] = Gen.identifier.map(LogicalResourceId(_))
-  implicit val arbLogicalResourceId: Arbitrary[LogicalResourceId] = Arbitrary(genLogicalResourceId)
-
-  val genPhysicalResourceId: Gen[PhysicalResourceId] = Gen.asciiPrintableStr.map(PhysicalResourceId(_))
-  implicit val arbPhysicalResourceId: Arbitrary[PhysicalResourceId] = Arbitrary(genPhysicalResourceId)
-}
+val genPhysicalResourceId: Gen[PhysicalResourceId] = Gen.asciiPrintableStr.map(PhysicalResourceId(_))
+given Arbitrary[PhysicalResourceId] = Arbitrary(genPhysicalResourceId)

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ec2/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ec2/ArbitraryInstances.scala
@@ -4,27 +4,23 @@ import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import software.amazon.awssdk.services.ec2.model.{Instance, Tag as AwsTag}
 
-object ArbitraryInstances extends ArbitraryInstances
+given Arbitrary[Ec2InstanceId] = Arbitrary(Gen.listOfN(17, Gen.hexChar).map(_.mkString("i-", "", "")).map(Ec2InstanceId(_)))
 
-trait ArbitraryInstances {
-  implicit val arbEc2InstanceId: Arbitrary[Ec2InstanceId] = Arbitrary(Gen.listOfN(17, Gen.hexChar).map(_.mkString("i-", "", "")).map(Ec2InstanceId(_)))
+val genAwsTag: Gen[AwsTag] =
+  for {
+    key <- Gen.identifier
+    value <- arbitrary[String]
+  } yield AwsTag.builder().key(key).value(value).build()
 
-  val genAwsTag: Gen[AwsTag] =
-    for {
-      key <- Gen.identifier
-      value <- arbitrary[String]
-    } yield AwsTag.builder().key(key).value(value).build()
-
-  val genInstance: Gen[Instance] =
-    for {
-      id <- arbitrary[Ec2InstanceId]
-      tags <- Gen.nonEmptyListOf(genAwsTag)
-    } yield {
-      Instance
-        .builder()
-        .instanceId(id.value)
-        .tags(tags *)
-        .build()
-    }
-  implicit val arbInstance: Arbitrary[Instance] = Arbitrary(genInstance)
-}
+val genInstance: Gen[Instance] =
+  for {
+    id <- arbitrary[Ec2InstanceId]
+    tags <- Gen.nonEmptyListOf(genAwsTag)
+  } yield {
+    Instance
+      .builder()
+      .instanceId(id.value)
+      .tags(tags *)
+      .build()
+  }
+given Arbitrary[Instance] = Arbitrary(genInstance)

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ecs/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ecs/ArbitraryInstances.scala
@@ -1,10 +1,11 @@
 package com.dwolla.aws.ecs
 
 import cats.syntax.all.*
-import com.dwolla.RandomChunks
-import com.dwolla.aws.ec2.{Ec2InstanceId, given}
 import com.dwolla.aws.{AccountId, given}
-import fs2.{Chunk, Stream}
+import com.dwolla.aws.ec2.{Ec2InstanceId, given}
+import com.dwolla.RandomChunks
+import com.dwolla.aws.ecs.TaskStatus.stoppedTaskStatuses
+import fs2.{Chunk, Pure, Stream}
 import monix.newtypes.NewtypeWrapped
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
@@ -12,16 +13,35 @@ import org.scalacheck.Arbitrary.arbitrary
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
+case class TaskArnAndStatus(arn: TaskArn, status: TaskStatus)
+case class ContainerInstanceWithTaskPages(containerInstanceId: ContainerInstanceId,
+                                          ec2InstanceId: Ec2InstanceId,
+                                          tasks: List[Chunk[TaskArnAndStatus]],
+                                          status: ContainerInstanceStatus,
+                                         ) {
+  def toContainerInstance: ContainerInstance =
+    ContainerInstance(
+      containerInstanceId,
+      ec2InstanceId,
+      TaskCount(tasks.foldMap(_.filterNot {
+        case TaskArnAndStatus(_, status) => stoppedTaskStatuses.contains(status)
+      }.size).toLong),
+      status)
+}
+
 type ArbitraryCluster = ArbitraryCluster.Type
 object ArbitraryCluster extends NewtypeWrapped[List[Chunk[ClusterWithInstances]]]
 
 type ClusterWithInstances = ClusterWithInstances.Type
-object ClusterWithInstances extends NewtypeWrapped[(Cluster, List[Chunk[ContainerInstance]])] {
+object ClusterWithInstances extends NewtypeWrapped[(Cluster, List[Chunk[ContainerInstanceWithTaskPages]])] {
   extension (cwi: ClusterWithInstances) {
     def cluster: Cluster = cwi.value._1
-    def pages: List[Chunk[ContainerInstance]] = cwi.value._2
+    def pages: List[Chunk[ContainerInstanceWithTaskPages]] = cwi.value._2
   }
 }
+
+type TasksForContainerInstance = TasksForContainerInstance.Type
+object TasksForContainerInstance extends NewtypeWrapped[List[Chunk[TaskArnAndStatus]]]
 
 def genRegion: Gen[Region] = Gen.oneOf(software.amazon.awssdk.regions.Region.regions().asScala).map(x => Region(x.id()))
 given Arbitrary[Region] = Arbitrary(genRegion)
@@ -29,39 +49,65 @@ given Arbitrary[Region] = Arbitrary(genRegion)
 def genContainerInstanceStatus: Gen[ContainerInstanceStatus] = Gen.oneOf(ContainerInstanceStatus.Active, ContainerInstanceStatus.Draining, ContainerInstanceStatus.Inactive)
 given Arbitrary[ContainerInstanceStatus] = Arbitrary(genContainerInstanceStatus)
 
-def genContainerInstance: Gen[ContainerInstance] =
+def genContainerInstanceWithTaskPages: Gen[ContainerInstanceWithTaskPages] =
   for {
     cId <- arbitrary[ContainerInstanceId]
     ec2Id <- arbitrary[Ec2InstanceId]
-    taskCount <- arbitrary[TaskCount]
+    taskCount <- arbitrary[TasksForContainerInstance]
     status <- arbitrary[ContainerInstanceStatus]
-  } yield ContainerInstance(cId, ec2Id, taskCount, status)
+  } yield ContainerInstanceWithTaskPages(cId, ec2Id, taskCount.value, status)
+given Arbitrary[ContainerInstanceWithTaskPages] = Arbitrary(genContainerInstanceWithTaskPages)
+
+def genContainerInstance: Gen[ContainerInstance] =
+  arbitrary[ContainerInstanceWithTaskPages].map(_.toContainerInstance)
 given Arbitrary[ContainerInstance] = Arbitrary(genContainerInstance)
 
-def genClusterWithInstances: Gen[ClusterWithInstances] =
+def genTaskArnAndStatus: Gen[TaskArnAndStatus] =
+  for {
+    arn <- arbitrary[TaskArn]
+    status <- arbitrary[TaskStatus]
+  } yield TaskArnAndStatus(arn, status)
+given Arbitrary[TaskArnAndStatus] = Arbitrary(genTaskArnAndStatus)
+
+private def chunkList[A](seed: Long)
+                        (list: List[A]): List[Chunk[A]] =
+  Stream.emits(list)
+    .through(RandomChunks[Pure, A](100, seed))
+    .chunks
+    .toList
+
+def genTasksForContainerInstance: Gen[TasksForContainerInstance] =
+  for {
+    seed <- arbitrary[Long]
+    totalTasks <- Gen.chooseNum(0, 40)
+    tasks <- Gen.containerOfN[List, TaskArnAndStatus](totalTasks, arbitrary[TaskArnAndStatus]).map(chunkList(seed))
+  } yield TasksForContainerInstance(tasks)
+given Arbitrary[TasksForContainerInstance] = Arbitrary(genTasksForContainerInstance)
+
+def genClusterWithInstances(containerBuilder: [T] => Gen[T] => Gen[List[T]]): Gen[ClusterWithInstances] =
   for {
     seed <- arbitrary[Long]
     cluster <- arbitrary[Cluster]
-    instances <- Gen.containerOf[List, ContainerInstance](genContainerInstance).map(_.take(10)).map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
+    instances <- containerBuilder(genContainerInstanceWithTaskPages).map(_.take(10)).map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
   } yield ClusterWithInstances(cluster -> instances)
-given Arbitrary[ClusterWithInstances] = Arbitrary(genClusterWithInstances)
+given Arbitrary[ClusterWithInstances] = Arbitrary(genClusterWithInstances([X] => Gen.containerOf[List, X](_: Gen[X])))
 
 def genClustersWithInstances: Gen[ArbitraryCluster] =
   Gen.long.flatMap { seed =>
-    Gen.nonEmptyContainerOf[List, ClusterWithInstances](arbitrary[ClusterWithInstances])
-      .suchThat { (f: List[ClusterWithInstances]) =>
-        def containerInstanceCount = f.unorderedFoldMap(_.value._2.flatMap(_.toList).size)
-        def containerInstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.containerInstanceId)).toSet.size == containerInstanceCount
-        def ec2InstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.ec2InstanceId)).toSet.size == containerInstanceCount
+    Gen.nonEmptyContainerOf[List, ClusterWithInstances](genClusterWithInstances([X] => Gen.nonEmptyContainerOf[List, X](_: Gen[X])))
+        .suchThat { (f: List[ClusterWithInstances]) =>
+          lazy val containerInstanceCount = f.unorderedFoldMap(_.value._2.flatMap(_.toList).size)
+          lazy val containerInstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.containerInstanceId)).toSet.size == containerInstanceCount
+          lazy val ec2InstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.ec2InstanceId)).toSet.size == containerInstanceCount
 
-        containerInstanceIdsAreUnique && ec2InstanceIdsAreUnique && containerInstanceCount > 0
-      }
+          containerInstanceIdsAreUnique && ec2InstanceIdsAreUnique && containerInstanceCount > 0
+        }
       .map(_.take(100))
       .map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
       .map(ArbitraryCluster(_))
   }
 given Arbitrary[ArbitraryCluster] = Arbitrary(genClustersWithInstances)
-given Shrink[ArbitraryCluster] = Shrink.shrinkAny
+implicit val shrinkArbitraryCluster: Shrink[ArbitraryCluster] = Shrink.shrinkAny
 
 def genContainerInstanceId: Gen[ContainerInstanceId] =
   arbitrary[UUID].map(_.toString).map(ContainerInstanceId(_))
@@ -87,7 +133,17 @@ def genTaskCount: Gen[TaskCount] =
 given Arbitrary[TaskCount] = Arbitrary(genTaskCount)
 
 val genTaskStatus: Gen[TaskStatus] =
-  Gen.frequency(1 -> TaskStatus.Pending, 10 -> TaskStatus.Running, 1 -> TaskStatus.Stopped)
+  Gen.frequency(
+    1 -> TaskStatus.Provisioning,
+      1 -> TaskStatus.Pending,
+      1 -> TaskStatus.Activating,
+      10 -> TaskStatus.Running,
+      1 -> TaskStatus.Deactivating,
+      1 -> TaskStatus.Stopping,
+      1 -> TaskStatus.Deprovisioning,
+      5 -> TaskStatus.Stopped,
+      5 -> TaskStatus.Deleted,
+  )
 given Arbitrary[TaskStatus] = Arbitrary(genTaskStatus)
 
 val genTaskArn: Gen[TaskArn] =

--- a/aws-testkit/src/main/scala/com/dwolla/aws/ecs/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ecs/ArbitraryInstances.scala
@@ -1,10 +1,9 @@
 package com.dwolla.aws.ecs
 
 import cats.syntax.all.*
-import com.dwolla.aws.AccountId
-import com.dwolla.aws.ArbitraryInstances.*
-import com.dwolla.aws.ec2.Ec2InstanceId
 import com.dwolla.RandomChunks
+import com.dwolla.aws.ec2.{Ec2InstanceId, given}
+import com.dwolla.aws.{AccountId, given}
 import fs2.{Chunk, Stream}
 import monix.newtypes.NewtypeWrapped
 import org.scalacheck.*
@@ -13,114 +12,110 @@ import org.scalacheck.Arbitrary.arbitrary
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
-object ArbitraryInstances extends ArbitraryInstances
+type ArbitraryCluster = ArbitraryCluster.Type
+object ArbitraryCluster extends NewtypeWrapped[List[Chunk[ClusterWithInstances]]]
 
-trait ArbitraryInstances {
-  type ArbitraryCluster = ArbitraryCluster.Type
-  object ArbitraryCluster extends NewtypeWrapped[List[Chunk[ClusterWithInstances]]]
-
-  type ClusterWithInstances = ClusterWithInstances.Type
-  object ClusterWithInstances extends NewtypeWrapped[(Cluster, List[Chunk[ContainerInstance]])] {
-    extension (cwi: ClusterWithInstances) {
-      def cluster: Cluster = cwi.value._1
-      def pages: List[Chunk[ContainerInstance]] = cwi.value._2
-    }
+type ClusterWithInstances = ClusterWithInstances.Type
+object ClusterWithInstances extends NewtypeWrapped[(Cluster, List[Chunk[ContainerInstance]])] {
+  extension (cwi: ClusterWithInstances) {
+    def cluster: Cluster = cwi.value._1
+    def pages: List[Chunk[ContainerInstance]] = cwi.value._2
   }
-
-  lazy val genRegion: Gen[Region] = Gen.oneOf(software.amazon.awssdk.regions.Region.regions().asScala).map(x => Region(x.id()))
-  implicit lazy val arbRegion: Arbitrary[Region] = Arbitrary(genRegion)
-
-  lazy val genContainerInstanceStatus: Gen[ContainerInstanceStatus] = Gen.oneOf(ContainerInstanceStatus.Active, ContainerInstanceStatus.Draining, ContainerInstanceStatus.Inactive)
-  implicit lazy val arbContainerInstanceStatus: Arbitrary[ContainerInstanceStatus] = Arbitrary(genContainerInstanceStatus)
-
-  lazy val genContainerInstance: Gen[ContainerInstance] =
-    for {
-      cId <- arbitrary[ContainerInstanceId]
-      ec2Id <- arbitrary[Ec2InstanceId]
-      taskCount <- arbitrary[TaskCount]
-      status <- arbitrary[ContainerInstanceStatus]
-    } yield ContainerInstance(cId, ec2Id, taskCount, status)
-  implicit lazy val arbContainerInstance: Arbitrary[ContainerInstance] = Arbitrary(genContainerInstance)
-
-  lazy val genClusterWithInstances: Gen[ClusterWithInstances] =
-    for {
-      seed <- arbitrary[Long]
-      cluster <- arbitrary[Cluster]
-      instances <- Gen.containerOf[List, ContainerInstance](arbContainerInstance.arbitrary).map(_.take(10)).map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
-    } yield ClusterWithInstances(cluster -> instances)
-  implicit lazy val arbClusterWithInstances: Arbitrary[ClusterWithInstances] = Arbitrary(genClusterWithInstances)
-
-  lazy val genClustersWithInstances: Gen[ArbitraryCluster] =
-    Gen.long.flatMap { seed =>
-      Gen.nonEmptyContainerOf[List, ClusterWithInstances](arbitrary[ClusterWithInstances])
-        .suchThat { (f: List[ClusterWithInstances]) =>
-          lazy val containerInstanceCount = f.unorderedFoldMap(_.value._2.flatMap(_.toList).size)
-          lazy val containerInstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.containerInstanceId)).toSet.size == containerInstanceCount
-          lazy val ec2InstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.ec2InstanceId)).toSet.size == containerInstanceCount
-
-          containerInstanceIdsAreUnique && ec2InstanceIdsAreUnique && containerInstanceCount > 0
-        }
-        .map(_.take(100))
-        .map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
-        .map(ArbitraryCluster(_))
-    }
-  implicit lazy val arbClustersWithInstances: Arbitrary[ArbitraryCluster] = Arbitrary(genClustersWithInstances)
-  implicit val shrinkArbitraryCluster: Shrink[ArbitraryCluster] = Shrink.shrinkAny
-
-  lazy val genContainerInstanceId: Gen[ContainerInstanceId] =
-    arbitrary[UUID].map(_.toString).map(ContainerInstanceId(_))
-  implicit lazy val arbContainerInstanceId: Arbitrary[ContainerInstanceId] = Arbitrary(genContainerInstanceId)
-
-  lazy val genCluster: Gen[Cluster] =
-    for {
-      region <- arbitrary[Region]
-      accountId <- arbitrary[AccountId]
-      clusterName <- arbitrary[ClusterName]
-    } yield Cluster(region, accountId, clusterName)
-  implicit lazy val arbCluster: Arbitrary[Cluster] = Arbitrary(genCluster)
-
-  lazy val genClusterArn: Gen[ClusterArn] = genCluster.map(_.clusterArn)
-  implicit lazy val arbClusterArn: Arbitrary[ClusterArn] = Arbitrary(genClusterArn)
-
-  lazy val genClusterName: Gen[ClusterName] =
-    Gen.oneOf("cluster1", "cluster2", "cluster3").map(ClusterName(_))
-  implicit lazy val arbClusterName: Arbitrary[ClusterName] = Arbitrary(genClusterName)
-
-  lazy val genTaskCount: Gen[TaskCount] =
-    Gen.chooseNum(0, 20).map(TaskCount(_))
-  implicit lazy val arbTaskCount: Arbitrary[TaskCount] = Arbitrary(genTaskCount)
-
-  val genTaskStatus: Gen[TaskStatus] =
-    Gen.frequency(1 -> TaskStatus.Pending, 10 -> TaskStatus.Running, 1 -> TaskStatus.Stopped)
-  implicit val arbTaskStatus: Arbitrary[TaskStatus] = Arbitrary(genTaskStatus)
-
-  val genTaskArn: Gen[TaskArn] =
-    for {
-      region <- genRegion
-      accountId <- arbitrary[AccountId]
-      taskId <- Gen.identifier
-    } yield TaskArn(s"arn:aws:ecs:$region:$accountId:task/$taskId")
-  implicit val arbTaskArn: Arbitrary[TaskArn] = Arbitrary(genTaskArn)
-
-  val genTask: Gen[(TaskArn, TaskStatus, TaskDefinitionArn)] =
-    for {
-      arn <- genTaskArn
-      status <- arbitrary[TaskStatus]
-      defnArn <- arbitrary[TaskDefinitionArn]
-    } yield (arn, status, defnArn)
-  val genListTaskPages: Gen[ListTaskPages] =
-    Gen.nonEmptyListOf(Gen.nonEmptyListOf(genTask)).map(ListTaskPages(_))
-  implicit val arbListTaskPages: Arbitrary[ListTaskPages] = Arbitrary(genListTaskPages)
-
-  val genTaskDefinitionArn: Gen[TaskDefinitionArn] =
-    for {
-      region <- genRegion
-      accountId <- arbitrary[AccountId]
-      name <- Gen.identifier
-      revision <- Gen.posNum[Int]
-    } yield TaskDefinitionArn(s"arn:aws:ecs:$region:$accountId:task-definition/$name:$revision")
-  implicit val arbTaskDefinitionArn: Arbitrary[TaskDefinitionArn] = Arbitrary(genTaskDefinitionArn)
 }
+
+def genRegion: Gen[Region] = Gen.oneOf(software.amazon.awssdk.regions.Region.regions().asScala).map(x => Region(x.id()))
+given Arbitrary[Region] = Arbitrary(genRegion)
+
+def genContainerInstanceStatus: Gen[ContainerInstanceStatus] = Gen.oneOf(ContainerInstanceStatus.Active, ContainerInstanceStatus.Draining, ContainerInstanceStatus.Inactive)
+given Arbitrary[ContainerInstanceStatus] = Arbitrary(genContainerInstanceStatus)
+
+def genContainerInstance: Gen[ContainerInstance] =
+  for {
+    cId <- arbitrary[ContainerInstanceId]
+    ec2Id <- arbitrary[Ec2InstanceId]
+    taskCount <- arbitrary[TaskCount]
+    status <- arbitrary[ContainerInstanceStatus]
+  } yield ContainerInstance(cId, ec2Id, taskCount, status)
+given Arbitrary[ContainerInstance] = Arbitrary(genContainerInstance)
+
+def genClusterWithInstances: Gen[ClusterWithInstances] =
+  for {
+    seed <- arbitrary[Long]
+    cluster <- arbitrary[Cluster]
+    instances <- Gen.containerOf[List, ContainerInstance](genContainerInstance).map(_.take(10)).map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
+  } yield ClusterWithInstances(cluster -> instances)
+given Arbitrary[ClusterWithInstances] = Arbitrary(genClusterWithInstances)
+
+def genClustersWithInstances: Gen[ArbitraryCluster] =
+  Gen.long.flatMap { seed =>
+    Gen.nonEmptyContainerOf[List, ClusterWithInstances](arbitrary[ClusterWithInstances])
+      .suchThat { (f: List[ClusterWithInstances]) =>
+        def containerInstanceCount = f.unorderedFoldMap(_.value._2.flatMap(_.toList).size)
+        def containerInstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.containerInstanceId)).toSet.size == containerInstanceCount
+        def ec2InstanceIdsAreUnique = f.flatMap(_.value._2.flatMap(_.toList).map(_.ec2InstanceId)).toSet.size == containerInstanceCount
+
+        containerInstanceIdsAreUnique && ec2InstanceIdsAreUnique && containerInstanceCount > 0
+      }
+      .map(_.take(100))
+      .map(Stream.emits(_).through(RandomChunks(100, seed)).chunks.toList)
+      .map(ArbitraryCluster(_))
+  }
+given Arbitrary[ArbitraryCluster] = Arbitrary(genClustersWithInstances)
+given Shrink[ArbitraryCluster] = Shrink.shrinkAny
+
+def genContainerInstanceId: Gen[ContainerInstanceId] =
+  arbitrary[UUID].map(_.toString).map(ContainerInstanceId(_))
+given Arbitrary[ContainerInstanceId] = Arbitrary(genContainerInstanceId)
+
+def genCluster: Gen[Cluster] =
+  for {
+    region <- arbitrary[Region]
+    accountId <- arbitrary[AccountId]
+    clusterName <- arbitrary[ClusterName]
+  } yield Cluster(region, accountId, clusterName)
+given Arbitrary[Cluster] = Arbitrary(genCluster)
+
+def genClusterArn: Gen[ClusterArn] = genCluster.map(_.clusterArn)
+given Arbitrary[ClusterArn] = Arbitrary(genClusterArn)
+
+def genClusterName: Gen[ClusterName] =
+  Gen.oneOf("cluster1", "cluster2", "cluster3").map(ClusterName(_))
+given Arbitrary[ClusterName] = Arbitrary(genClusterName)
+
+def genTaskCount: Gen[TaskCount] =
+  Gen.chooseNum(0, 20).map(TaskCount(_))
+given Arbitrary[TaskCount] = Arbitrary(genTaskCount)
+
+val genTaskStatus: Gen[TaskStatus] =
+  Gen.frequency(1 -> TaskStatus.Pending, 10 -> TaskStatus.Running, 1 -> TaskStatus.Stopped)
+given Arbitrary[TaskStatus] = Arbitrary(genTaskStatus)
+
+val genTaskArn: Gen[TaskArn] =
+  for {
+    region <- genRegion
+    accountId <- arbitrary[AccountId]
+    taskId <- Gen.identifier
+  } yield TaskArn(s"arn:aws:ecs:$region:$accountId:task/$taskId")
+given Arbitrary[TaskArn] = Arbitrary(genTaskArn)
+
+val genTask: Gen[(TaskArn, TaskStatus, TaskDefinitionArn)] =
+  for {
+    arn <- genTaskArn
+    status <- arbitrary[TaskStatus]
+    defnArn <- arbitrary[TaskDefinitionArn]
+  } yield (arn, status, defnArn)
+val genListTaskPages: Gen[ListTaskPages] =
+  Gen.nonEmptyListOf(Gen.nonEmptyListOf(genTask)).map(ListTaskPages(_))
+given Arbitrary[ListTaskPages] = Arbitrary(genListTaskPages)
+
+val genTaskDefinitionArn: Gen[TaskDefinitionArn] =
+  for {
+    region <- genRegion
+    accountId <- arbitrary[AccountId]
+    name <- Gen.identifier
+    revision <- Gen.posNum[Int]
+  } yield TaskDefinitionArn(s"arn:aws:ecs:$region:$accountId:task-definition/$name:$revision")
+given Arbitrary[TaskDefinitionArn] = Arbitrary(genTaskDefinitionArn)
 
 type ListTaskPages = ListTaskPages.Type
 object ListTaskPages extends NewtypeWrapped[List[List[(TaskArn, TaskStatus, TaskDefinitionArn)]]]

--- a/aws-testkit/src/main/scala/com/dwolla/aws/sns/ArbitraryInstances.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/sns/ArbitraryInstances.scala
@@ -1,18 +1,13 @@
 package com.dwolla.aws.sns
 
-import com.dwolla.aws.AccountId
-import com.dwolla.aws.ArbitraryInstances.*
-import com.dwolla.aws.ecs.Region
+import com.dwolla.aws.{AccountId, given}
+import com.dwolla.aws.ecs.{Region, given}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 
-object ArbitraryInstances extends ArbitraryInstances
-
-trait ArbitraryInstances {
-  implicit val arbSnsTopicArn: Arbitrary[SnsTopicArn] =
-    Arbitrary(for {
-      region <- arbitrary[Region]
-      accountId <- arbitrary[AccountId]
-      topicName <- Gen.alphaNumStr
-    } yield SnsTopicArn(s"arn:aws:sns:$region:$accountId:$topicName"))
-}
+given Arbitrary[SnsTopicArn] =
+  Arbitrary(for {
+    region <- arbitrary[Region]
+    accountId <- arbitrary[AccountId]
+    topicName <- Gen.alphaNumStr
+  } yield SnsTopicArn(s"arn:aws:sns:$region:$accountId:$topicName"))

--- a/core-tests/src/test/scala/com/dwolla/aws/autoscaling/AutoScalingAlgImplSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/autoscaling/AutoScalingAlgImplSpec.scala
@@ -3,10 +3,10 @@ package com.dwolla.aws.autoscaling
 import cats.effect.*
 import cats.effect.std.Dispatcher
 import cats.effect.testkit.TestControl
-import com.dwolla.aws.ArbitraryInstances
 import com.dwolla.aws.autoscaling.LifecycleState.*
-import com.dwolla.aws.sns.{SnsAlg, SnsTopicArn}
+import com.dwolla.aws.autoscaling.given
 import com.dwolla.aws.ec2.Ec2InstanceId
+import com.dwolla.aws.sns.{SnsAlg, SnsTopicArn, given}
 import io.circe.syntax.*
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF.forAllF
@@ -21,10 +21,9 @@ import scala.jdk.CollectionConverters.*
 
 class AutoScalingAlgImplSpec
   extends CatsEffectSuite
-  with ScalaCheckEffectSuite
-  with ArbitraryInstances {
+    with ScalaCheckEffectSuite {
 
-  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+  given LoggerFactory[IO] = NoOpFactory[IO]
 
   test("AutoScalingAlgImpl should make an async completeLifecycleAction request to continueAutoScaling") {
     forAllF { (arbLifecycleHookNotification: LifecycleHookNotification) =>

--- a/core-tests/src/test/scala/com/dwolla/aws/autoscaling/LifecycleHookHandlerSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/autoscaling/LifecycleHookHandlerSpec.scala
@@ -5,8 +5,9 @@ import _root_.io.circe.literal.*
 import _root_.io.circe.syntax.*
 import cats.effect.*
 import cats.syntax.all.*
-import com.dwolla.aws.ArbitraryInstances
-import com.dwolla.aws.sns.SnsTopicArn
+import com.dwolla.aws
+import com.dwolla.aws.autoscaling.given
+import com.dwolla.aws.sns.{SnsTopicArn, given}
 import feral.lambda.events.SnsEvent
 import feral.lambda.{Context, ContextInstances, LambdaEnv}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -17,10 +18,9 @@ import org.typelevel.log4cats.noop.NoOpFactory
 class LifecycleHookHandlerSpec
   extends CatsEffectSuite
     with ScalaCheckEffectSuite
-    with ArbitraryInstances
     with ContextInstances {
 
-  private implicit val noopLoggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+  given LoggerFactory[IO] = NoOpFactory[IO]
   private def snsMessage[T: Encoder](topic: SnsTopicArn, detail: T, maybeSubject: Option[String]): Json =
     json"""{
              "Records": [

--- a/core-tests/src/test/scala/com/dwolla/aws/cloudformation/CloudFormationAlgSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/cloudformation/CloudFormationAlgSpec.scala
@@ -2,10 +2,11 @@ package com.dwolla.aws.cloudformation
 
 import cats.effect.*
 import cats.effect.std.Dispatcher
-import com.dwolla.aws.*
+import com.dwolla.aws
+import com.dwolla.aws.cloudformation.given
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.scalacheck.effect.PropF.forAllF
 import org.scalacheck.Arbitrary
+import org.scalacheck.effect.PropF.forAllF
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
 import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
@@ -16,10 +17,9 @@ import scala.jdk.CollectionConverters.*
 
 class CloudFormationAlgSpec
   extends CatsEffectSuite
-    with ScalaCheckEffectSuite
-    with ArbitraryInstances {
+    with ScalaCheckEffectSuite {
 
-  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+  given LoggerFactory[IO] = NoOpFactory[IO]
 
   test("CloudFormationAlg should return the physical resource ID for the given parameters, if it can") {
     forAllF { (stack: StackArn,

--- a/core-tests/src/test/scala/com/dwolla/aws/cloudformation/TestApp.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/cloudformation/TestApp.scala
@@ -7,7 +7,7 @@ import org.typelevel.log4cats.noop.NoOpFactory
 import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient
 
 object TestApp extends ResourceApp.Simple {
-  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+  given LoggerFactory[IO] = NoOpFactory[IO]
 
   private def stackArn = StackArn(???)
   private val logicalResourceId = LogicalResourceId(???)

--- a/core-tests/src/test/scala/com/dwolla/aws/ec2/Ec2AlgSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/ec2/Ec2AlgSpec.scala
@@ -9,16 +9,17 @@ import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
 import software.amazon.awssdk.services.ec2.Ec2AsyncClient
 import software.amazon.awssdk.services.ec2.model.{DescribeInstancesRequest, DescribeInstancesResponse, Instance, Reservation}
+import com.dwolla.aws
 
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters.*
+import com.dwolla.aws.ec2.given
 
 class Ec2AlgSpec
   extends CatsEffectSuite
-    with ScalaCheckEffectSuite
-    with ArbitraryInstances {
+    with ScalaCheckEffectSuite {
 
-  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+  given LoggerFactory[IO] = NoOpFactory[IO]
 
   test("Ec2Alg should retrieve the tags for an instance") {
     forAllF { (instance: Instance) =>

--- a/core-tests/src/test/scala/com/dwolla/aws/sns/SnsAlgSpec.scala
+++ b/core-tests/src/test/scala/com/dwolla/aws/sns/SnsAlgSpec.scala
@@ -2,7 +2,8 @@ package com.dwolla.aws.sns
 
 import cats.effect.*
 import cats.effect.std.Dispatcher
-import com.dwolla.aws.ArbitraryInstances
+import com.dwolla.aws
+import com.dwolla.aws.sns.given
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF.forAllF
 import org.typelevel.log4cats.*
@@ -15,10 +16,9 @@ import java.util.concurrent.CompletableFuture
 
 class SnsAlgSpec
   extends CatsEffectSuite
-    with ScalaCheckEffectSuite
-    with ArbitraryInstances {
+    with ScalaCheckEffectSuite {
 
-  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+  given LoggerFactory[IO] = NoOpFactory[IO]
 
   test("SnsAlg should publish a message using the underlying client") {
     forAllF { (topic: SnsTopicArn, message: String, messageId: UUID) =>

--- a/core/src/main/scala/com/dwolla/aws/autoscaling/AutoScalingAlg.scala
+++ b/core/src/main/scala/com/dwolla/aws/autoscaling/AutoScalingAlg.scala
@@ -31,7 +31,7 @@ object AutoScalingAlg {
 class AutoScalingAlgImpl[F[_] : Async : LoggerFactory](autoScalingClient: AutoScalingAsyncClient,
                                                        sns: SnsAlg[F]) extends AutoScalingAlg[F] {
   private def getInstanceLifecycleState(ec2Instance: Ec2InstanceId): F[Option[LifecycleState]] =
-    LoggerFactory[F].create.flatMap { implicit logger =>
+    LoggerFactory[F].create.flatMap { case given Logger[F] =>
       for {
         _ <- Logger[F].info(s"checking lifecycle state for instance $ec2Instance")
         req = DescribeAutoScalingInstancesRequest.builder().instanceIds(ec2Instance.value).build()
@@ -53,7 +53,7 @@ class AutoScalingAlgImpl[F[_] : Async : LoggerFactory](autoScalingClient: AutoSc
                               ): F[Unit] = {
     val sleepDuration = 5.seconds
 
-    LoggerFactory[F].create.flatMap { implicit logger =>
+    LoggerFactory[F].create.flatMap { case given Logger[F] =>
       Logger[F].info(s"Sleeping for $sleepDuration, then restarting Lambda") >>
         getInstanceLifecycleState(l.EC2InstanceId)
           .map(_.contains(onlyIfInState))

--- a/core/src/main/scala/com/dwolla/aws/autoscaling/LifecycleHookHandler.scala
+++ b/core/src/main/scala/com/dwolla/aws/autoscaling/LifecycleHookHandler.scala
@@ -10,7 +10,7 @@ import org.typelevel.log4cats.LoggerFactory
 
 object LifecycleHookHandler {
   def apply[F[_] : MonadThrow : LoggerFactory](eventBridge: (SnsTopicArn, LifecycleHookNotification) => F[Unit])
-                                              (implicit C: fs2.Compiler[F, F]): LambdaEnv[F, SnsEvent] => F[Option[INothing]] = env =>
+                                              (using fs2.Compiler[F, F]): LambdaEnv[F, SnsEvent] => F[Option[INothing]] = env =>
     Stream.eval(env.event)
       .map(_.records)
       .flatMap(Stream.emits(_))

--- a/core/src/main/scala/com/dwolla/aws/autoscaling/model.scala
+++ b/core/src/main/scala/com/dwolla/aws/autoscaling/model.scala
@@ -41,7 +41,7 @@ case class TestNotification(accountId: AccountId,
                            ) extends AutoScalingSnsMessage
 
 object LifecycleHookNotification extends DerivedCirceCodec {
-  implicit val lifecycleHookNotificationEncoder: Encoder[LifecycleHookNotification] =
+  given Encoder[LifecycleHookNotification] =
     Encoder.forProduct10(
       "Service",
       "Time",
@@ -66,7 +66,7 @@ object LifecycleHookNotification extends DerivedCirceCodec {
         a.notificationMetadata
       )
     }
-  implicit val lifecycleHookNotificationDecoder: Decoder[LifecycleHookNotification] =
+  given Decoder[LifecycleHookNotification] =
     Decoder.forProduct10(
       "Service",
       "Time",
@@ -81,7 +81,7 @@ object LifecycleHookNotification extends DerivedCirceCodec {
     )(LifecycleHookNotification.apply)
 }
 object TestNotification extends DerivedCirceCodec {
-  implicit val testNotificationEncoder: Encoder[TestNotification] =
+  given Encoder[TestNotification] =
     Encoder.forProduct7(
       "AccountId",
       "RequestId",
@@ -100,7 +100,7 @@ object TestNotification extends DerivedCirceCodec {
         x.time,
       )
     }
-  implicit val testNotificationDecoder: Decoder[TestNotification] =
+  given Decoder[TestNotification] =
     Decoder.forProduct7(
       "AccountId",
       "RequestId",
@@ -113,7 +113,7 @@ object TestNotification extends DerivedCirceCodec {
 }
 
 object AutoScalingSnsMessage {
-  implicit val autoScalingSnsMessageDecoder: Decoder[AutoScalingSnsMessage] =
+  given Decoder[AutoScalingSnsMessage] =
     Decoder[LifecycleHookNotification].widen[AutoScalingSnsMessage]
       .or(Decoder[TestNotification].widen[AutoScalingSnsMessage])
 }

--- a/core/src/main/scala/com/dwolla/aws/cloudformation/CloudFormationAlg.scala
+++ b/core/src/main/scala/com/dwolla/aws/cloudformation/CloudFormationAlg.scala
@@ -24,7 +24,7 @@ trait CloudFormationAlg[F[_]] {
 object CloudFormationAlg {
   def apply[F[_] : Async : LoggerFactory](client: CloudFormationAsyncClient): CloudFormationAlg[F] = new CloudFormationAlg[F] {
     override def physicalResourceIdFor(stack: StackArn, logicalResourceId: LogicalResourceId): F[Option[PhysicalResourceId]] =
-      LoggerFactory[F].create.flatMap { implicit l =>
+      LoggerFactory[F].create.flatMap { case given Logger[F] =>
         val req = DescribeStackResourceRequest.builder()
           .stackName(stack.value)
           .logicalResourceId(logicalResourceId.value)

--- a/core/src/main/scala/com/dwolla/aws/ec2/Ec2Alg.scala
+++ b/core/src/main/scala/com/dwolla/aws/ec2/Ec2Alg.scala
@@ -22,7 +22,7 @@ object Ec2Alg {
     override def getTagsForInstance(id: Ec2InstanceId): F[List[Tag]] = {
       val req = DescribeInstancesRequest.builder().instanceIds(id.value).build()
 
-      LoggerFactory[F].create.flatMap { implicit L =>
+      LoggerFactory[F].create.flatMap { case given Logger[F] =>
         for {
           _ <- Logger[F].info(s"describing instance ${id.value}")
           resp <- Async[F].fromCompletableFuture(

--- a/core/src/main/scala/com/dwolla/aws/ecs/model.scala
+++ b/core/src/main/scala/com/dwolla/aws/ecs/model.scala
@@ -14,7 +14,7 @@ type ClusterName = ClusterName.Type
 object ClusterName extends NewtypeWrapped[String]
 type TaskCount = TaskCount.Type
 object TaskCount extends NewtypeWrapped[Int] {
-  implicit val order: Order[TaskCount] = Order[Int].contramap(_.value)
+  given Order[TaskCount] = Order[Int].contramap(_.value)
 }
 type Region = Region.Type
 object Region extends NewtypeWrapped[String]

--- a/core/src/main/scala/com/dwolla/aws/sns/SnsAlg.scala
+++ b/core/src/main/scala/com/dwolla/aws/sns/SnsAlg.scala
@@ -13,7 +13,7 @@ trait SnsAlg[F[_]] {
 object SnsAlg {
   def apply[F[_] : Async : LoggerFactory](client: SnsAsyncClient): SnsAlg[F] = new SnsAlg[F] {
     override def publish(topic: SnsTopicArn, message: String): F[Unit] =
-      LoggerFactory[F].create.flatMap { implicit l =>
+      LoggerFactory[F].create.flatMap { case given Logger[F] =>
         val req = PublishRequest.builder()
           .topicArn(topic.value)
           .message(message)

--- a/core/src/main/scala/com/dwolla/aws/sns/model.scala
+++ b/core/src/main/scala/com/dwolla/aws/sns/model.scala
@@ -5,6 +5,6 @@ import monix.newtypes.*
 
 type SnsTopicArn = SnsTopicArn.Type
 object SnsTopicArn extends NewtypeWrapped[String] {
-  implicit val snsTopicArnEncoder: Encoder[SnsTopicArn] = Encoder[String].contramap(_.value)
-  implicit val snsTopicArnDecoder: Decoder[SnsTopicArn] = Decoder[String].map(SnsTopicArn(_))
+  given Encoder[SnsTopicArn] = Encoder[String].contramap(_.value)
+  given Decoder[SnsTopicArn] = Decoder[String].map(SnsTopicArn(_))
 }

--- a/draining/src/main/scala/com/dwolla/autoscaling/ecs/draining/TerminationEventBridge.scala
+++ b/draining/src/main/scala/com/dwolla/autoscaling/ecs/draining/TerminationEventBridge.scala
@@ -13,7 +13,7 @@ class TerminationEventBridge[F[_] : Monad, G[_]](ECS: EcsAlg[F, G], AutoScaling:
       maybeInstance <- ECS.findEc2Instance(lifecycleHook.EC2InstanceId)
       tasksRemaining <- maybeInstance match {
         case Some((cluster, ci)) =>
-          ECS.drainInstance(cluster, ci).as(ci.runningTaskCount > TaskCount(0))
+          ECS.drainInstance(cluster, ci).as(ci.countOfTasksNotStopped > TaskCount(0))
         case None => false.pure[F]
       }
       _ <- if (tasksRemaining) AutoScaling.pauseAndRecurse(topic, lifecycleHook, TerminatingWait) else AutoScaling.continueAutoScaling(lifecycleHook)

--- a/draining/src/test/scala/com/dwolla/autoscaling/ecs/draining/TerminationEventBridgeSpec.scala
+++ b/draining/src/test/scala/com/dwolla/autoscaling/ecs/draining/TerminationEventBridgeSpec.scala
@@ -1,19 +1,17 @@
 package com.dwolla.autoscaling.ecs.draining
 
 import cats.effect.*
-import com.dwolla.aws
-import com.dwolla.aws.autoscaling.*
 import com.dwolla.aws.autoscaling.LifecycleState.TerminatingWait
+import com.dwolla.aws.autoscaling.{*, given}
 import com.dwolla.aws.ec2.Ec2InstanceId
-import com.dwolla.aws.ecs.*
-import com.dwolla.aws.sns.SnsTopicArn
+import com.dwolla.aws.ecs.{*, given}
+import com.dwolla.aws.sns.{SnsTopicArn, given}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF.forAllF
 
 class TerminationEventBridgeSpec 
   extends CatsEffectSuite 
-    with ScalaCheckEffectSuite 
-    with aws.ArbitraryInstances {
+    with ScalaCheckEffectSuite {
 
   test("TerminationEventBridge should mark a non-draining instance as draining and pause and recurse") {
     forAllF { (arbSnsTopicArn: SnsTopicArn, 

--- a/registrator-health-check/src/test/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridgeSpec.scala
+++ b/registrator-health-check/src/test/scala/com/dwolla/autoscaling/ecs/registrator/ScaleOutPendingEventBridgeSpec.scala
@@ -3,21 +3,20 @@ package com.dwolla.autoscaling.ecs.registrator
 import cats.*
 import cats.effect.*
 import cats.syntax.all.*
-import com.dwolla.aws.*
-import com.dwolla.aws.autoscaling.*
 import com.dwolla.aws.autoscaling.AdvanceLifecycleHook.*
 import com.dwolla.aws.autoscaling.LifecycleState.PendingWait
-import com.dwolla.aws.cloudformation.*
+import com.dwolla.aws.autoscaling.{*, given}
+import com.dwolla.aws.cloudformation.{*, given}
 import com.dwolla.aws.ec2.*
-import com.dwolla.aws.ecs.*
-import com.dwolla.aws.sns.SnsTopicArn
+import com.dwolla.aws.ecs.{*, given}
+import com.dwolla.aws.sns.{SnsTopicArn, given}
+import com.dwolla.aws.{*, given}
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
 import org.scalacheck.effect.PropF.forAllF
 
 class ScaleOutPendingEventBridgeSpec
   extends CatsEffectSuite
-    with ScalaCheckEffectSuite
-    with com.dwolla.aws.ArbitraryInstances {
+    with ScalaCheckEffectSuite {
 
   test("ScaleOutPendingEventBridge continues autoscaling when Registrator is running on instance") {
     forAllF { (arbTopic: SnsTopicArn,


### PR DESCRIPTION
The changes in this PR implement the advice AWS gave us to ensure that instances don't terminate prior to stopping tasks fully shutting down.

30d859f55a09ff6de236ec05c05ac03cfd838a45 is the commit that contains the changes in the behavior. Instead of relying on the `runningTaskCount` value returned by the AWS `DescribeContainerInstance` API call, we now describe all the tasks running on the instance and look at their status. They will now only count as not running if they are in the `STOPPED` or `DELETED` statuses, which means the lifecycle hook will now prevent instance termination when tasks are `DEACTIVATING`, `STOPPING`, or `DEPROVISIONING`.

487d969d8e5fb8b7d6aee74c52d5c2ca6a302834 and d46de78a560fb36df1eafcb592c7786decf13cf5 are refactoring commits and shouldn't change any behavior. 487d969d8e5fb8b7d6aee74c52d5c2ca6a302834 finishes converting a bunch of context values (the artists formally known as implicits) to Scala 3 syntax, which I did in part because I was seeing slow performance in some of the ScalaCheck tests, and profiling seemed to indicate that at least some of that was happening when the `object`s containing the `implicit` definitions were initializing. I think in the end the refactoring did not end up helping with performance, but this style is the way Scala 3 wants these to be implemented anyway, so I think it's best to move forward with them this way.

