### PR TITLE
use a CQL query to narrow down the EC2 instances returned by listContainerInstances when searching by instance ID

### DIFF
--- a/aws-testkit/src/main/scala/com/dwolla/aws/ecs/TestEcsAlg.scala
+++ b/aws-testkit/src/main/scala/com/dwolla/aws/ecs/TestEcsAlg.scala
@@ -6,7 +6,7 @@ import com.dwolla.aws.ecs.*
 
 abstract class TestEcsAlg extends EcsAlg[IO, List] {
   override def listClusterArns: List[ClusterArn] = ???
-  override def listContainerInstances(cluster: ClusterArn): List[ContainerInstance] = ???
+  override def listContainerInstances(cluster: ClusterArn, filter: Option[CQLQuery]): List[ContainerInstance] = ???
   override def findEc2Instance(ec2InstanceId: InstanceId): IO[Option[(ClusterArn, ContainerInstance)]] = IO.raiseError(new NotImplementedError)
   override def isTaskDefinitionRunningOnInstance(cluster: ClusterArn, ci: ContainerInstance, taskDefinition: TaskDefinitionArn): IO[Boolean] = IO.raiseError(new NotImplementedError)
   override def drainInstanceImpl(cluster: ClusterArn, ci: ContainerInstance): IO[Unit] = IO.raiseError(new NotImplementedError)

--- a/core/src/main/scala/com/dwolla/aws/ecs/model.scala
+++ b/core/src/main/scala/com/dwolla/aws/ecs/model.scala
@@ -27,6 +27,9 @@ object TaskCount extends NewtypeWrapped[Long] {
   given Order[TaskCount] = Order[Long].contramap(_.value)
 }
 
+type CQLQuery = CQLQuery.Type
+object CQLQuery extends NewtypeWrapped[String]
+
 case class Cluster(region: AwsRegion, accountId: AccountId, name: ClusterName) {
   val clusterArn: ClusterArn = ClusterArn(s"arn:aws:ecs:$region:$accountId:cluster/$name")
 }

--- a/draining/src/test/scala/com/dwolla/autoscaling/ecs/draining/TestApp.scala
+++ b/draining/src/test/scala/com/dwolla/autoscaling/ecs/draining/TestApp.scala
@@ -35,7 +35,7 @@ object TestApp extends ResourceApp.Simple {
           .flatMap { ecs =>
             ecs.listClusterArns
               .filter(_.value.contains("Production"))
-              .flatMap(ecs.listContainerInstances)
+              .flatMap(ecs.listContainerInstances(_))
           }
           .evalMap(c => IO.println(c))
           .compile


### PR DESCRIPTION
This should dramatically reduce the number of `ListContainerInstances`, `DescribeContainerInstances`, `ListTasks`, and `DescribeTasks` calls made by the Draining lambda.