### PR TITLE
fix IAM action name to grant permission to describe stack resources

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,7 +29,7 @@ provider:
             - "ecs:ListTasks"
             - "ecs:DescribeTasks"
             - "ec2:DescribeInstances"
-            - "cloudformation:DescribeStackResource"
+            - "cloudformation:DescribeStackResources"
           Resource: "*"
           Effect: Allow
         - Sid: RepublishMessages


### PR DESCRIPTION
Currently the scale out hook fails due to
```xml
<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
  <Error>
    <Type>Sender</Type>
    <Code>AccessDenied</Code>
    <Message>User: arn:aws:sts::REDACTED:assumed-role/ecs-autoscaling-lifecycle-hooks-admin-us-west-2-lambdaRole/ecs-autoscaling-lifecycle-hooks-admin-ConfirmRegistratorHealth is not authorized to perform: cloudformation:DescribeStackResources on resource: arn:aws:cloudformation:us-west-2:REDACTED:stack/REDACTED because no identity-based policy allows the cloudformation:DescribeStackResources action</Message>
  </Error>
  <RequestId>REDACTED</RequestId>
</ErrorResponse>
```

but I think this should fix that.