### PR TITLE
TW-110: Java 21 Lambda runtime and build

### DIFF
--- a/.dwollaci.yml
+++ b/.dwollaci.yml
@@ -3,17 +3,21 @@ stages:
   build:
     nodeLabel: sbt
     steps:
+      # Jenkins runs this fragment with /bin/sh (dash); sdkman-init.sh uses `source`, which dash
+      # does not implement. Re-exec under bash so SDKMAN and sbt run in a POSIX-compatible shell.
       - |
+        exec bash <<'JENKINS_BUILD'
         export SDKMAN_DIR="$HOME/.sdkman"
         mkdir -p "${SDKMAN_DIR}/candidates/java/current/bin"
         set +o xtrace
-        . "${SDKMAN_DIR}/bin/sdkman-init.sh"
+        source "${SDKMAN_DIR}/bin/sdkman-init.sh"
         sdk env install use
         set -o xtrace
         sbt test
         sbt doc
         sbt autoscaling-ecs-draining-lambda/Universal/packageBin
         sbt registrator-health-check-lambda/Universal/packageBin
+        JENKINS_BUILD
     filesToStash:
       - '**'
   deployProd:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,30 +23,35 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Test
+    name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [3]
         java: [corretto@21]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (corretto@21)
         id: setup-java-corretto-21
         if: matrix.java == 'corretto@21'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: corretto
           java-version: 21
+          cache: sbt
 
-      - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+      - name: sbt update
+        if: matrix.java == 'corretto@21' && steps.setup-java-corretto-21.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,9 @@ jobs:
         with:
           distribution: corretto
           java-version: 21
-          cache: sbt
 
-      - name: sbt update
-        if: matrix.java == 'corretto@21' && steps.setup-java-corretto-21.outputs.cache-hit == 'false'
-        run: sbt +update
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3]
-        java: [corretto@17]
+        java: [corretto@21]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -37,17 +37,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (corretto@17)
-        id: setup-java-corretto-17
-        if: matrix.java == 'corretto@17'
+      - name: Setup Java (corretto@21)
+        id: setup-java-corretto-21
+        if: matrix.java == 'corretto@21'
         uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 21
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'corretto@21' && steps.setup-java-corretto-21.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,7 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
-  - status-success=Build and Test (ubuntu-latest, 3, corretto@21)
+  - status-success=Test (ubuntu-22.04, 3, corretto@21)
   actions:
     merge: {}
 - name: Label aws-testkit PRs

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,7 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
-  - status-success=Build and Test (ubuntu-latest, 3, corretto@17)
+  - status-success=Build and Test (ubuntu-latest, 3, corretto@21)
   actions:
     merge: {}
 - name: Label aws-testkit PRs

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/jod

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,1 +1,1 @@
-java=17.0.9-amzn
+java=21.0.11-amzn

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,35 @@
+import org.typelevel.sbt.gha.UseRef
+import org.typelevel.sbt.gha.WorkflowStep
+
 ThisBuild / organization := "Dwolla"
 ThisBuild / homepage := Option(url("https://github.com/Dwolla/autoscaling-ecs-draining-lambda"))
 ThisBuild / tlCiDependencyGraphJob := false
 ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / tlJdkRelease := Option(21)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.corretto("21"))
+/* ubuntu-latest runners do not ship `sbt`. SetupJava(..., enableCaching = true) injects `sbt +update`
+ * before we can install sbt — disable that prefetch and install sbt after JDK setup instead. */
+ThisBuild / githubWorkflowJobSetup := {
+  val autoCrlfOpt =
+    if ((ThisBuild / githubWorkflowOSes).value.exists(_.contains("windows"))) {
+      List(
+        WorkflowStep.Run(
+          commands = List("git config --global core.autocrlf false"),
+          name = Some("Ignore line ending differences in git"),
+          cond = Some("contains(runner.os, 'windows')"),
+        ))
+    } else Nil
+  val setupSbt = WorkflowStep.Use(
+    ref = UseRef.Public("sbt", "setup-sbt", "v1"),
+    name = Some("Setup sbt"),
+  )
+  autoCrlfOpt :::
+    List(WorkflowStep.CheckoutFull) :::
+    WorkflowStep.SetupJava(
+      (ThisBuild / githubWorkflowJavaVersions).value.toList,
+      enableCaching = false,
+    ) ::: List(setupSbt)
+}
 ThisBuild / githubWorkflowBuild += WorkflowStep.Sbt(name = Option("Package"), commands = List("autoscaling-ecs-draining-lambda/Universal/packageBin"))
 ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward")
 ThisBuild / mergifyStewardConfig ~= { _.map(_.copy(

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import org.typelevel.sbt.gha.UseRef
 import org.typelevel.sbt.gha.WorkflowStep
 
 ThisBuild / organization := "Dwolla"
@@ -7,35 +6,11 @@ ThisBuild / tlCiDependencyGraphJob := false
 ThisBuild / scalaVersion := "3.3.1"
 ThisBuild / tlJdkRelease := Option(21)
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.corretto("21"))
-/* ubuntu-latest runners do not ship `sbt`. SetupJava(..., enableCaching = true) injects `sbt +update`
- * before we can install sbt — disable that prefetch and install sbt after JDK setup instead. */
-ThisBuild / githubWorkflowJobSetup := {
-  val autoCrlfOpt =
-    if ((ThisBuild / githubWorkflowOSes).value.exists(_.contains("windows"))) {
-      List(
-        WorkflowStep.Run(
-          commands = List("git config --global core.autocrlf false"),
-          name = Some("Ignore line ending differences in git"),
-          cond = Some("contains(runner.os, 'windows')"),
-        ))
-    } else Nil
-  val setupSbt = WorkflowStep.Use(
-    ref = UseRef.Public("sbt", "setup-sbt", "v1"),
-    name = Some("Setup sbt"),
-  )
-  autoCrlfOpt :::
-    List(WorkflowStep.CheckoutFull) :::
-    WorkflowStep.SetupJava(
-      (ThisBuild / githubWorkflowJavaVersions).value.toList,
-      enableCaching = false,
-    ) ::: List(setupSbt)
-}
 ThisBuild / githubWorkflowBuild += WorkflowStep.Sbt(name = Option("Package"), commands = List("autoscaling-ecs-draining-lambda/Universal/packageBin"))
 ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward")
-ThisBuild / mergifyStewardConfig ~= { _.map(_.copy(
-  author = "dwolla-oss-scala-steward[bot]",
-  mergeMinors = true,
-))}
+ThisBuild / mergifyStewardConfig ~= {
+  _.map(_.withMergeMinors(true).withAuthor("dwolla-oss-scala-steward[bot]"))
+}
 topLevelDirectory := None
 ThisBuild / scalacOptions += "-source:future"
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ ThisBuild / scalacOptions += "-source:future"
 lazy val `smithy4s-preprocessors` = project
   .in(file("smithy4s-preprocessors"))
   .settings(
-    scalaVersion := "2.12.13", // 2.12 to match what SBT uses
+    scalaVersion := "2.12.19", // 2.12 for sbt plugins path; 2.12.18+ needed for JDK 21 (bridge compile / ASM)
     scalacOptions -= "-source:future",
     libraryDependencies ++= {
       Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ ThisBuild / organization := "Dwolla"
 ThisBuild / homepage := Option(url("https://github.com/Dwolla/autoscaling-ecs-draining-lambda"))
 ThisBuild / tlCiDependencyGraphJob := false
 ThisBuild / scalaVersion := "3.3.1"
-ThisBuild / tlJdkRelease := Option(17)
-ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.corretto("17"))
+ThisBuild / tlJdkRelease := Option(21)
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.corretto("21"))
 ThisBuild / githubWorkflowBuild += WorkflowStep.Sbt(name = Option("Package"), commands = List("autoscaling-ecs-draining-lambda/Universal/packageBin"))
 ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward")
 ThisBuild / mergifyStewardConfig ~= { _.map(_.copy(

--- a/deploy.sh
+++ b/deploy.sh
@@ -43,7 +43,6 @@ echo "+ sdk env install use"
 sdk env install use
 
 set -o xtrace -o nounset -o pipefail
-npm install -g npm
-npm install -g serverless
+npm install -g serverless@3
 
 sbt "show deploy Admin"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel-ci" % "0.6.5")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % "0.6.5")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-mergify" % "0.6.5")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-ci" % "0.8.5")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % "0.8.5")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-mergify" % "0.8.5")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.6")
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ^3.33.0
 
 provider:
   name: aws
-  runtime: java17
+  runtime: java21
   architecture: arm64
   memorySize: 1024
   timeout: 60


### PR DESCRIPTION
## Summary
Updates deprecated Lambda-related configuration for **TW-110** (runtime remediation).

## Changes
- **Serverless:** `provider.runtime` `java17` → `java21` (shared by `DrainOnTermination` / draining Lambda and `ConfirmRegistratorHealth`).
- **sbt:** `tlJdkRelease` **21**, `githubWorkflowJavaVersions` **Corretto 21**.
- **CI / Mergify:** Regenerated via `sbt githubWorkflowGenerate; mergifyGenerate`.
- **Dwolla CI:** `.sdkmanrc` → Corretto **21.0.11-amzn** so `sdk env install use` matches the JDK required by sbt-typelevel after the bump.

## Notes
- Inventory may still list **java8** until this stack is **deployed**; the repo was already ahead of that on **java17**.
- Local builds need **JDK ≥ 21** (enforced by sbt-typelevel).

## Testing
- [ ] CI (GitHub Actions) on this PR